### PR TITLE
Pygame-RPG 9.2 Housekeeping and bugfixing

### DIFF
--- a/managers/Save_Manager_test.py
+++ b/managers/Save_Manager_test.py
@@ -5,6 +5,7 @@ import random
 from managers.Dummy_Knight import Knight
 from managers.Save_Manager import SaveManager
 from managers.Screen_Manager import ScreenManager
+from managers.Screen_Manager import Event
 
 # Replicating an actual game
 game.init()
@@ -21,6 +22,7 @@ x = 500
 test_dict = {}
 knight_dict = {}
 screenManager_dict = {}
+eventDict = {}
 localVars = vars()
 saveManager = SaveManager(knight, localVars)
 Knight2 = Knight()
@@ -50,6 +52,29 @@ def fill_knight_dict():
 def fill_screenManager_dict():
     screenManager_dict.update({"context": screenManager.context})
     screenManager_dict.update({"objectDict": screenManager.objectDict})
+
+def fill_event_dict():
+    interactablesVars = {}
+    for key in screenManager.interactablesDict:
+        eventsVar = []
+        eventsTuple = screenManager.interactablesDict[key]
+        for i in range(len(eventsTuple)):
+            eventsVar.append(vars(eventsTuple[i]))
+        interactablesVars.update({key: tuple(eventsVar)})
+    eventDict.update(interactablesVars)
+
+def verify_interactables():
+    flag = True
+    event = Event((300, 400), "")  # Just for init. These values mean nothing
+    for key in screenManager.interactablesDict:
+        i = 0
+        dictVals = eventDict[key]
+        while i < len(dictVals) and flag:
+            event.load(dictVals[i])
+            flag = event == screenManager.interactablesDict[key][i]
+            i += 1
+    return flag
+
 animationTracker = random.randint(1, 100)
 animationTracker2 = random.randint(1, 100)
 animationTracker3 = random.randint(1, 100)
@@ -59,10 +84,12 @@ x = random.randint(-280, 1000)
 screenManager.change_screen(1000)  # Move to right screen
 for i in range(random.randint(1, 10)):
     knight.levelup()
+
 def test_quick_save():
     fill_knight_dict()
     fill_test_dict()
     fill_screenManager_dict()
+    fill_event_dict()
     saveManager.quick_save(screenManager)
     assert saveManager.saveNumber == 0  # Shouldn't change
 
@@ -78,6 +105,8 @@ def test_quick_load():
         flag = (Knight2 == knight)
     if flag:
         flag = (screenManager.context == screenManager_dict["context"] and screenManager.objectDict == screenManager_dict["objectDict"])
+    if flag:
+        flag = verify_interactables()
     assert flag
 
 animationTracker = random.randint(1, 100)
@@ -92,6 +121,7 @@ def test_save(): #slot #4
     fill_knight_dict()
     fill_test_dict()
     fill_screenManager_dict()
+    fill_event_dict()
     saveManager.save(4, screenManager)
     assert saveManager.saveNumber == 4  # Should now be 4
 
@@ -107,6 +137,8 @@ def test_load():  # slot #4
         flag = (Knight2 == knight)
     if flag:
         flag = (screenManager.context == screenManager_dict["context"] and screenManager.objectDict == screenManager_dict["objectDict"])
+    if flag:
+        flag = verify_interactables()
     assert flag
 
 def test_latest_file():  # check if last save is 4

--- a/managers/Screen_Manager.py
+++ b/managers/Screen_Manager.py
@@ -9,6 +9,15 @@ class Event:
         self.activated = False
         self.path = path
 
+    def load(self, infoDict):
+        self.range = tuple(infoDict["range"])
+        self.eventType = infoDict["eventType"]
+        self.activated = infoDict["activated"]
+        self.path = infoDict["path"]
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
 # Screen manager should draw the actual stuff I guess?
 # For now there's only going to be two options moving to the left screen and moving to the right screen
 # Moving to right screen = 1
@@ -17,8 +26,9 @@ chestB1 = Event((500, 600), "Chest")
 screen_dict = {("Background1", 1): "Background2", ("Background2", -1): "Background1"}
 background_dict ={"Background1": "Background_Art/gothic_chapel_portfolio_1422x800.png",
                   "Background2": "Background_Art/PNG/game_background_1/game_background_1.png"}
-interactables_dict = {"Background1": (chestB1, ), "Background2": ()}
-objects_dict = {"Background1": ((800, 500), True), "Background2": ()} # NEEDS TO BE SAVED
+interactables_dict = {"Background1": (chestB1, ), "Background2": ()}   # NEEDS TO BE SAVED
+objects_dict = {"Background1": ((800, 500), True), "Background2": ()}  # NEEDS TO BE SAVED
+
 class ScreenManager:
     def __init__(self, screen):
         self.interactables = ()
@@ -27,7 +37,9 @@ class ScreenManager:
         self.objects = ()
         self.objectAni = ObjectAnimationManager()
         self.objectDict = objects_dict
+        self.interactablesDict = interactables_dict
         self.apply_context()
+
 
     def change_screen(self, pos):
         mover = 0
@@ -57,3 +69,4 @@ class ScreenManager:
         self.context = context
         self.screen = game.image.load(background_dict.get(self.context))  # Draws the screen based on the new context
         self.apply_context()  # Applies the current context to reload the other things on screen
+


### PR DESCRIPTION
### Pygame-RPG 9.2 Housekeeping and bugfixing
It was discovered that the states of the events were saved by SaveManager. This led to a glitch where you could open a chest, load a previous save from before you opened the chest and be unable to open said chest. As such, SaveManager needed to be changed to include this vital feature. Tests for this were also written and have been confirmed to work.

Other changes:
- created the `load()` function for the Event class to simplify updating the JSON information into the object.
- created the `load_data()` function to simplify loading information in SaveManager
- formatting changes
## PR checklist
 - [ ✅  ] All Pytests pass
 - [ ✅ ] All changes are documented somewhere in the commit
 - [ ✅ ] Rpg2.py is tested and works even with the changes
 