### PR TITLE
Pygame-RPG 10.2 Housekeeping and bugfixing

### DIFF
--- a/Scripts.py
+++ b/Scripts.py
@@ -142,9 +142,9 @@ if __name__ == "__main__":
     if arg == "fill-save":
         screenManager = ScreenManager(screen)
         knight = Knight()
-        saveManager = SaveManager(knight, vars())
+        saveManager = SaveManager(knight, vars(), screenManager)
         for i in range(4):
-            saveManager.save(i+1, screenManager)
+            saveManager.save(i+1)
 
     elif arg == "run-tests":
         uiManager = UIManager(font, screen)

--- a/managers/Dialogue_Manager.py
+++ b/managers/Dialogue_Manager.py
@@ -1,24 +1,28 @@
 import os
 import pygame as game
+import time
 
 # Dict that will point to the files where the dialogue still is
 text_dict = {}
 # Portrait dict takes in a name and then gets the portrait
 portrait_dict = {"Knight": game.image.load("portraits/Knight.png"), "Rion": game.image.load("portraits/Knight.png")}
 class DialogueManager: 
-    def __init__(self ):
-        self.file = None
-        self.portrait = None 
+    def __init__(self, font, screen):
+        self.file = None      # File that's being read from
+        self.portrait = None  # Portrait that's displayed on screen
+        self.font = font      # Font used to write dialogue
+        self.screen = screen  # For drawing things
         self.name = ""
         self.characterBox = game.image.load("portraits/character_box.png")
         self.textBox = game.image.load("portraits/text_box.png")
-        self.event = None
-        self.prevText = ""
+        self.event = None     # Event that's currently loaded
+        self.prevText = ""    # Previous text
     
     def load_file(self, event):
         # Loads the file that we read from
-        self.event = event
-        self.file = open(event.path)
+        self.event = event  # Stored event
+        self.file = open(event.path)  # file that's being accessed
+        self.prevText = self.get_text()  # Sets previous text by default
     
     # Returns a single text line. Probably going to have to enforce a char limit too huh...
     def get_text(self):
@@ -27,12 +31,12 @@ class DialogueManager:
         # Clears file's value if EOF has been reached.
         if text == "":
             self.clear_file()
-            self.prevText = "1"
         else:
             text = self.load_portrait(text)
         return text
     
     def clear_file(self):
+        # Clears the file and the event associated with it
         self.file.close()
         self.event.activated = True
         self.event = None
@@ -53,3 +57,26 @@ class DialogueManager:
         self.portrait = portrait_dict.get(name)  # This can be None btw so there has to be logic checking this
         # Returns text that has name stripped from it
         return text
+    def draw_dialogue(self, eventList):  # For stuff like this reading from event list might be better
+        # Make this able to show previous dialogue when you tab
+
+        text = self.prevText
+        for event in eventList:
+            if event.type == game.KEYDOWN:
+                if event.key == game.K_RETURN:
+                    text = self.get_text()
+                    break  # Should break after
+        textSurface = self.font.render(text, False, "Red")
+        if self.portrait is not None:
+            nameSurface = self.font.render(self.name, False, "Red")
+            self.screen.blit(self.characterBox, (0, 650))
+            self.screen.blit(self.portrait, (15, 670))
+            self.screen.blit(nameSurface, (20, 620))
+            self.screen.blit(self.textBox, (120, 650))
+            self.screen.blit(textSurface, (140, 670))
+        else:
+            # This way there's no awkward space where the portrait used to be.
+            self.screen.blit(self.textBox, (0, 650))
+            self.screen.blit(textSurface, (20, 670))
+        # There is an easier way to do this, but it makes my eyes bleed so no :)
+        return text != ""

--- a/managers/Dialogue_Manager_test.py
+++ b/managers/Dialogue_Manager_test.py
@@ -1,16 +1,35 @@
+import pygame
+
 from managers.Dialogue_Manager import DialogueManager
 from managers.Screen_Manager import Event
+import pygame as game
 
-dialogueManager = DialogueManager()
+game.init()
+screen = game.display.set_mode((1422, 800))
+clock = game.time.Clock()
+game.display.set_caption("Legend of Zeroes, Trails of Cold Meals")
+font = game.font.Font('font/Pixeltype.ttf', 50)
+dialogueManager = DialogueManager(font, screen)
 mockDialogEvent = Event(None, "Dialogue","event_text/Test_dialogue.txt")
 
-def mock_draw_dialogue(dialogueTimer):
+def get_size_of_file(event):
+    i = 0
+    file = open(event.path, "r")
+    text = file.readline()
+    while text != "":
+        text = file.readline()
+        i += 1
+    file.close()
+    return i
+
+def mock_draw_dialogue():
     # Version of draw_dialogue that doesn't do any of the drawing.
+    actualLen = get_size_of_file(mockDialogEvent)
+    len = 1  # Once the file is loaded, the first line is already read
     text = dialogueManager.prevText
-    if dialogueTimer % 180 == 0:
-        text = dialogueManager.get_text()
-    # There is an easier way to do this but it makes my eyes bleed so no :)
-    return text != ""
+    flag = dialogueManager.prevText != ""  # When loading the file prevText should have first line
+
+    return flag
 def test_load_file():
     # Load file just uses open() to get a file object. Loading a valid file should 
     # actually load the file thus making file not None
@@ -19,14 +38,17 @@ def test_load_file():
 
 def test_clear_file():
     # Checks if the file value in the manager is None and the file is cleared properly
-    # Also checks if the events activated value has been changed. This logic is going to cause problems in the future
-    # But that is future Keith's problem.
-    dialogueManager.load_file(mockDialogEvent)
-    dialogueTimer = 180
-    flag = True
-    file = dialogueManager.file
+    # Also checks if all the lines were properly read.
+    # Also checks if the events activated value has been changed. Might need to add a
+    # 'repeatable' value to events in the case of repeatable dialogue etc
+    fileLength = get_size_of_file(mockDialogEvent)  # Gets the length of the file
+    dialogueManager.load_file(mockDialogEvent)  # Loads the event
+    file = dialogueManager.file  # Create reference to file to check if closed later
+    length = 0
+    flag = dialogueManager.prevText != ""
     while flag:
-        flag = mock_draw_dialogue(dialogueTimer)
-        dialogueTimer += 1
-    # Might make dialogueManager keep the file even after it has been closed.
-    assert file.closed and dialogueManager.file is None and mockDialogEvent.activated
+        game.event.post(game.event.Event(pygame.KEYDOWN, key=game.K_RETURN))  # Creates the keydown event
+        eventList = game.event.get()  # Returns the list of events
+        flag = dialogueManager.draw_dialogue(eventList)  # draw dialogue call
+        length += 1  # Increment the size
+    assert file.closed and dialogueManager.file is None and mockDialogEvent.activated and length == fileLength

--- a/managers/Save_Manager_test.py
+++ b/managers/Save_Manager_test.py
@@ -77,7 +77,7 @@ localVars = vars()
 list = os.listdir("save/")
 if len(list) != 0:
     cleanup()
-saveManager = SaveManager(knight, localVars)
+saveManager = SaveManager(knight, localVars, screenManager)
 Knight2 = Knight()
 
 
@@ -96,12 +96,12 @@ def test_quick_save():
     fill_test_dict()
     fill_screenManager_dict()
     fill_event_dict()
-    saveManager.quick_save(screenManager)
+    saveManager.quick_save()
     assert saveManager.saveNumber == 1  # Shouldn't change
 
 def test_quick_load():
     Knight2.load_dict(knight_dict)
-    saveManager.quick_load(screenManager)
+    saveManager.quick_load()
     flag = True
     for key in test_dict:
         if localVars[key] != test_dict[key]:
@@ -128,12 +128,12 @@ def test_save(): #slot #4
     fill_test_dict()
     fill_screenManager_dict()
     fill_event_dict()
-    saveManager.save(4, screenManager)
+    saveManager.save(4)
     assert saveManager.saveNumber == 4  # Should now be 4
 
 def test_load():  # slot #4
     Knight2.load_dict(knight_dict)
-    saveManager.load(4, screenManager)
+    saveManager.load(4)
     flag = True
     for key in test_dict:
         if localVars[key] != test_dict[key]:
@@ -148,7 +148,7 @@ def test_load():  # slot #4
     assert flag
 
 def test_latest_file():  # check if last save is 4
-    newManager = SaveManager(Knight, vars())
+    newManager = SaveManager(Knight, vars(), screenManager)
     #cleanup()  # Gets rid of the save files created in the test
     assert newManager.saveNumber == 4  # Should still be 4
 

--- a/script
+++ b/script
@@ -8,7 +8,7 @@ case $args in
     ;;
 
   fill-save)
-      python scripts.py
+      python scripts.py fill-save
     ;;
 
   run-tests)


### PR DESCRIPTION
### Pygame-RPG 10.2 Housekeeping and bugfixing

This series of housekeeping changes is aimed at simplifying the overall structure of the project. These simplifications mostly include the addition of functions to the Rpg2.py file. The following functions were created for these purposes:

`handle_basic_input()`: takes in keys, knightAni, knight object, x and animationTracker to handle the basic movement of the knight character. returns x position of knight and animationTracker

`handle_player_interaction()`: takes in keys, knight object, various managers along with textEnable and animationTracker3 to handle the knight objects interactions with events. For now this is only in the form of opening a chest. Returns textEnable and animationTracker3

`draw_objects()`: takes in screen, screenManager and spot3. This function is responsible for drawing any and all objects that appear on the screen.

`change_screen()`: takes in x position, screenManger and NPCManager. This code is responsible for the switching of screens.

These changes have made dealing with the Rpg2.py file simpler and easier to handle. Another change to the Rpg2.py file is the fact that the `draw_dialogue()` function is now a part of Dialogue_Manager.py. This is to make it more explicit that it is DialogueManagers responsibility for that part of the game. For the most part, changes to Rpg2.py could be classified as general restructuring since not much new code was added.

Other changes:
- DialogueManager class now uses events from Pygame event queue to work
  instead of a timer. The event loop breaks after one 'enter' press is processed. This disables chained 'enter' presses which
  leads to a smoother experience overall.
- Changes made to Dialogue_Manager.py are reflected in Dialogue_Manager_test.py
- SaveManager class now has a reference to any manager it saves data from so it does not have to be passed into the
  `save()` and `load()` functions.
- Save_Manager_test.py file now reflects the changes made in Save_Manager.py
- Script.py fill-save functionality reflects the changes made in Save_Manager.py
- script file now has the proper flag when calling for the fill-save functionality in Scripts.py
- removed unneeded imports (Not too thorough on doing this though in this PR)
## Things to note
These changes have impacted the initial frame rate of the game, causing it to dip farther upon loading the game. Since the frame rate fixes itself to near 60 in mere seconds however, I consider this to not be a problem.

Another thing to note is that Pygame doesn't seem to like it when multiple surfaces are drawing. This leads to some assets still being on the screen when they shouldn't be. As such, only the `screen` variable will do the drawing.
## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 