### PR TITLE
Pygame-RPG 10.3 Housekeeping and bigfixing

### DIFF
--- a/Scripts.py
+++ b/Scripts.py
@@ -1,138 +1,11 @@
 #!/usr/bin/python
-import os
-
 from managers import SaveManager
 from managers import ScreenManager
-from managers import UIManager
 import pygame as game
-import json
 from Knight import Knight
 import sys
-import keyboard
 
-keys_dict = {"s": game.K_s, "w": game.K_w, "a": game.K_a, "d": game.K_d, "enter": game.K_RETURN, "esc": game.K_ESCAPE}
-def ensure_pressed(key):
-    while True:
-        for event in game.event.get():
-            if event.type == game.QUIT:
-                game.quit()
-                exit()
-        keys = game.key.get_pressed()
-        keyboard.press(key)
-        if keys[keys_dict.get(key)]:
-            return keys
-    
-def ui_test_1(uiManager, result_dict):
-    # move cursor down twice and test if it behaves as expected
-    keys = ensure_pressed("s")  # ensure s is being pressed
-    for a in range(2):
-        uiManager.draw_UI(keys)  # Moves cursor down twice
-    keyboard.release("s")        # release s key for future
-    result_dict.update({"test1": {
-        "pos": uiManager.cursor.pos[1]  # save the y cursor position
-    }})
-
-def ui_test_2(uiManager, result_dict):
-    # get the result from pressing enter and save to dict
-    keys = ensure_pressed("enter")  # ensure enter is being pressed
-    result = uiManager.draw_UI(keys)  # get the result from pressing enter
-    keyboard.release("enter")  # release enter key
-    result_dict.update({"test2": {    # save result list to dict
-        "result": tuple(result)
-    }})
-
-
-def ui_test_3(uiManager, result_dict):
-    # Change UI to reset cursor pos and test if wrap around works in both ways
-    uiManager.change_UI("Load Game")  # change the UI to load game
-    keys = ensure_pressed("w")  # ensure w is pressed
-    uiManager.draw_UI(keys)  # move the cursor
-    keyboard.release("w")    # release w key
-    # Now the cursor should be at the lowest position
-    flag = uiManager.cursor.pos[1] == (uiManager.constraint_y[1] - 20)  # check if cursor is in proper position
-    flag2 = False  # set second flag
-    flag3 = False  # set third flag
-    if flag:
-        keys = ensure_pressed("w")  # ensure s is pressed
-        uiManager.draw_UI(keys)  # move the cursor
-        keyboard.release("w")    # release s
-        # checks if moving up works as intended
-        # since we're moving up, y is actually subtracted
-        flag2 = uiManager.cursor.pos[1] == (uiManager.constraint_y[1] - uiManager.spacing_y - 20)  # 20 was the chosen offset
-        if flag2:
-            keys = ensure_pressed("s")  # ensure s is pressed
-            for i in range(2):
-                uiManager.draw_UI(keys)  # move the cursor down twice to wrap around
-            keyboard.release("s")  # release s
-            # Checks if the cursor wrapped around as intended
-            flag3 = uiManager.cursor.pos[1] == (uiManager.constraint_y[0] - 20)
-
-    result_dict.update({"test3": {  # stores the flag values in the dict 
-        "flag": flag,
-        "flag2": flag2,
-        "flag3": flag3
-    }})
-
-def ui_test_4(uiManager, result_dict):
-    # try to go back a UI and save the states
-    keys = ensure_pressed("esc")  # ensure escape is pressed 
-    uiManager.draw_UI(keys)  # test to see if the wrap around works
-    keyboard.release("esc")  # release escape key
-    # Confirms that we went back to start screen and that nothing was added to prevUIs
-    result_dict.update({"test4": {  # store UI and prevUI info in the dict
-        "UI": uiManager.UI,
-        "prevUIs": tuple(uiManager.prevUIs)
-    }})
-
-def ui_test_5(uiManager, result_dict):
-    # tests the results of all possible horizontal movement
-    uiManager.change_UI("Startv2")  # change to a UI that has horizontal UI
-    keys = ensure_pressed("d")    # move to the right once
-    uiManager.draw_UI(keys)
-    keyboard.release("d")
-    # check if normal movement is observed when moving to the right
-    flag = uiManager.cursor.pos[0] == (uiManager.constraint_x[1] - 80)
-    flag2 = False
-    flag3 = False
-    flag4 = False
-    if flag:
-        keys = ensure_pressed("a")  # move to the left once
-        uiManager.draw_UI(keys)
-        keyboard.release("a")
-        # see if the cursor position went back to the original spot
-        flag2 = uiManager.cursor.pos[0] == (uiManager.constraint_x[0] - 80)
-        if flag2:
-            # test wrap around left
-            keys = ensure_pressed("a")  # move to the left once
-            uiManager.draw_UI(keys)
-            keyboard.release("a")
-            # check if wrap around succeeded
-            flag3 = uiManager.cursor.pos[0] == (uiManager.constraint_x[1] - 80)
-            if flag3:
-                keys = ensure_pressed("d")  # move to the right once
-                uiManager.draw_UI(keys)
-                keyboard.release("d")
-                flag4 = uiManager.cursor.pos[0] == (uiManager.constraint_x[0] - 80)
-    result_dict.update({"test5": {
-        "flag": flag,
-        "flag2": flag2,
-        "flag3": flag3,
-        "flag4": flag4
-    }})
-
-def ui_test_6(uiManager, result_dict):
-    uiManager.change_UI("Startv2")  # change to appropriate UI
-    keys = ensure_pressed("d")    # Move right once
-    uiManager.draw_UI(keys)
-    keyboard.release("d")
-    keys = ensure_pressed("s")    # move down once
-    uiManager.draw_UI(keys)
-    keyboard.release("s")
-    keys = ensure_pressed("enter")  # press enter once
-    result = uiManager.draw_UI(keys)  # save result
-    result_dict.update({"test6": {    # save result list to dict
-        "result": tuple(result)
-    }})
+game.init()
 
 if __name__ == "__main__":
     game.init()
@@ -145,27 +18,5 @@ if __name__ == "__main__":
         saveManager = SaveManager(knight, vars(), screenManager)
         for i in range(4):
             saveManager.save(i+1)
-
-    elif arg == "run-tests":
-        uiManager = UIManager(font, screen)
-        result_dict = {}
-        ui_test_1(uiManager, result_dict)
-        ui_test_2(uiManager, result_dict)
-        ui_test_3(uiManager, result_dict)
-        ui_test_4(uiManager, result_dict)
-        ui_test_5(uiManager, result_dict)
-        ui_test_6(uiManager, result_dict)
-        os.chdir("testDetails/")
-        file = open("test_results.json", "w")
-        json.dump(result_dict, file,  indent=3)
-        file.close()
-        os.chdir("../")
-
-    elif arg == "test":
-        pass
-        #os.chdir("testDetails")
-        #print(os.getcwd())
-        #os.chdir("../")
-        #print(os.getcwd())
     game.quit()
     exit()

--- a/managers/UI_Manager.py
+++ b/managers/UI_Manager.py
@@ -1,5 +1,4 @@
 import pygame as game
-import time
 from managers.UI_Manager_draw import *
 # File responsible for drawing UI
 
@@ -52,9 +51,8 @@ class Cursor:
             self.pos = (self.xConstraints[0], self.yConstraints[0])
 
 
-    def handle_cursor(self, keys):
+    def handle_cursor(self, eventList):
         select = False
-        # For readability
         xMin = self.xConstraints[0]  # Starting point for x btw
         xMax = self.xConstraints[1]
 
@@ -63,33 +61,35 @@ class Cursor:
 
         xPos = self.pos[0]
         yPos = self.pos[1]
-        if (keys[game.K_RIGHT] or keys[game.K_d]) and self.spacingX != 0:
-            xPos += self.spacingX
-            if xPos > xMax:
-                xPos = xMin
-        elif (keys[game.K_LEFT] or keys[game.K_a]) and self.spacingX != 0:
-            xPos -= self.spacingX
-            if xPos < xMin:
-                xPos = xMax
-        elif keys[game.K_DOWN] or keys[game.K_s]:
-            # Inverted because Pygame is weird
-            yPos += self.spacingY
-            if yPos > yMax:
-                yPos = yMin
-        elif keys[game.K_UP] or keys[game.K_w]:
-            # Inverted because Pygame is weird
-            yPos -= self.spacingY
-            if yPos < yMin:
-                yPos = yMax
-        elif keys[game.K_RETURN]:
-            select = True
-        elif keys[game.K_ESCAPE]:
-            # Backtrack time
-            select = None
-            pass
+
+        # For readability
+        for event in eventList:
+            if event.type == game.KEYDOWN:
+                if event.key == game.K_RETURN:
+                    select = True
+                    break  # Breaks because this indicates a transition to another screen
+                elif event.key == game.K_ESCAPE:
+                    select = None
+                    break  # Breaks because this indicates a transition to another screen
+                elif event.key == game.K_RIGHT and self.spacingX != 0:
+                    xPos += self.spacingX
+                    if xPos > xMax:
+                        xPos = xMin
+                elif event.key == game.K_LEFT and self.spacingX != 0:
+                    xPos -= self.spacingX
+                    if xPos < xMin:
+                        xPos = xMax
+                elif event.key == game.K_DOWN:
+                    # Inverted because Pygame is weird
+                    yPos += self.spacingY
+                    if yPos > yMax:
+                        yPos = yMin
+                elif event.key == game.K_UP:
+                    # Inverted because Pygame is weird
+                    yPos -= self.spacingY
+                    if yPos < yMin:
+                        yPos = yMax
         self.pos = (xPos, yPos)
-        time.sleep(0.08)  # Adding a delay to make the UI feel smoother otherwise
-        # The UI is too responsive
         return select
 
 class UIManager:
@@ -126,7 +126,7 @@ class UIManager:
 
         
     # Draws the UI based on current state. Assets are game assets that need to be loaded in for certain UIs
-    def draw_UI(self, keys, assets=None):  
+    def draw_UI(self, eventList, assets=None):
         # Function that actually draws what's on screen
         # Assets should be drawn first so we don't cover up the text
         title = title_dict.get(self.UI)
@@ -157,7 +157,7 @@ class UIManager:
             else:
                 pos[1] += self.spacing_y  # Increment y's position
 
-        return self.handle_cursor(keys)
+        return self.handle_cursor(eventList)
     
     # Funtion that handles the position of the cursor
     def handle_cursor(self, keys):

--- a/managers/UI_Manager_test.py
+++ b/managers/UI_Manager_test.py
@@ -1,23 +1,31 @@
 import pygame as game
 from managers import UIManager
-import json
+
 game.init()
 screen = game.display.set_mode((1422, 800))
 font = game.font.Font('font/Pixeltype.ttf', 50)
-#keys = game.key.get_pressed()
 uiManager = UIManager(font, screen)
-test_info = json.load(open("testDetails/test_results.json", "r"))  # because of script, this should always exist
+keys_dict = {"s": game.K_DOWN, "w": game.K_UP, "a": game.K_LEFT, "d": game.K_RIGHT, "enter": game.K_RETURN,
+             "esc": game.K_ESCAPE}
+def get_keydown_event(key):
+    game.event.post(game.event.Event(game.KEYDOWN, key=keys_dict[key]))  # Create keydown event and add to queue
+    return game.event.get()  # Get the event queue also removes all events from queue
 def test_init():
    # Starting UI is always "Start" and there are no prevUIs
-    assert uiManager.UI is 'Start' and len(uiManager.prevUIs) == 0
+    assert uiManager.UI == 'Start' and len(uiManager.prevUIs) == 0
 
 def test_cursor_movement_down():
-    # Checks if the cursur was successfully moved down twice
-    yPos = test_info["test1"]["pos"]
+    # Checks if the cursor was successfully moved down twice
+    eventList = get_keydown_event("s")  # ensure s is being pressed
+    for a in range(2):
+        uiManager.draw_UI(eventList)  # Moves cursor down twice
+    yPos = uiManager.cursor.pos[1]  # Get the y position of cursor
     assert yPos == (uiManager.constraint_y[1] - 20)  # 20 was the chosen offset
 
 def test_confirmation_input():
-    result = test_info["test2"]["result"]
+    # get the result from pressing enter and save to dict
+    eventList = get_keydown_event("enter")  # ensure enter is being pressed
+    result = uiManager.draw_UI(eventList)  # get the result from pressing enter
     assert list(result) == ["Start", "Load Game"]
 
 def test_move_to_Load_screen():
@@ -26,31 +34,70 @@ def test_move_to_Load_screen():
     assert uiManager.UI == "Load Game" and uiManager.prevUIs[0] == "Start"
 
 def test_wrap_around_vertical():
-    test_dict = test_info["test3"]
-    flag = test_dict["flag"]
-    flag2 = test_dict["flag2"]
-    flag3 = test_dict["flag3"]
+    # Change UI to reset cursor pos and test if wrap around works in both ways
+    eventList = get_keydown_event("w")  # ensure w is pressed
+    uiManager.draw_UI(eventList)  # move the cursor
+    # Now the cursor should be at the lowest position
+    flag = uiManager.cursor.pos[1] == (uiManager.constraint_y[1] - 20)  # check if cursor is in proper position
+    flag2 = False  # set second flag
+    flag3 = False  # set third flag
+    if flag:
+        eventList = get_keydown_event("w")  # ensure s is pressed
+        uiManager.draw_UI(eventList)  # move the cursor
+        # checks if moving up works as intended
+        # since we're moving up, y is actually subtracted
+        flag2 = uiManager.cursor.pos[1] == (
+                    uiManager.constraint_y[1] - uiManager.spacing_y - 20)  # 20 was the chosen offset
+        if flag2:
+            eventList = get_keydown_event("s")  # ensure s is pressed
+            for i in range(2):
+                uiManager.draw_UI(eventList)  # move the cursor down twice to wrap around
+            # Checks if the cursor wrapped around as intended
+            flag3 = uiManager.cursor.pos[1] == (uiManager.constraint_y[0] - 20)
     assert flag and flag2 and flag3
 
 def test_back_track():
-    test_dict = test_info["test4"]
-    ui = test_dict["UI"]
-    prevUIs = test_dict["prevUIs"]
-    assert ui == "Start" and len(prevUIs) == 0
+    # try to go back a UI and save the states
+    eventList = get_keydown_event("esc")  # ensure escape is pressed
+    uiManager.draw_UI(eventList)  # test to see if the wrap around works
+    # Confirms that we went back to start screen and that nothing was added to prevUIs
+    assert uiManager.UI == "Start" and len(uiManager.prevUIs) == 0
 
 def test_horizontal_movement():
-    # tests if the horizontal movements are working as intended
-    print(test_info)
-    test_dict = test_info["test5"]
-    flag = test_dict["flag"]
-    flag2 = test_dict["flag2"]
-    flag3 = test_dict["flag3"]
-    flag4 = test_dict["flag4"]
+    # tests the results of all possible horizontal movement
+    uiManager.change_UI("Startv2")  # change to a UI that has horizontal UI
+    eventList = get_keydown_event("d")    # move to the right once
+    uiManager.draw_UI(eventList)
+    # check if normal movement is observed when moving to the right
+    flag = uiManager.cursor.pos[0] == (uiManager.constraint_x[1] - 80)
+    flag2 = False
+    flag3 = False
+    flag4 = False
+    if flag:
+        eventList = get_keydown_event("a")  # move to the left once
+        uiManager.draw_UI(eventList)
+        # see if the cursor position went back to the original spot
+        flag2 = uiManager.cursor.pos[0] == (uiManager.constraint_x[0] - 80)
+        if flag2:
+            # test wrap around left
+            eventList = get_keydown_event("a")  # move to the left once
+            uiManager.draw_UI(eventList)
+            # check if wrap around succeeded
+            flag3 = uiManager.cursor.pos[0] == (uiManager.constraint_x[1] - 80)
+            if flag3:
+                eventList = get_keydown_event("d")  # move to the right once
+                uiManager.draw_UI(eventList)
+                flag4 = uiManager.cursor.pos[0] == (uiManager.constraint_x[0] - 80)
     assert flag and flag2 and flag3 and flag4
 
 def test_horizontal_confirmation_input():
-    # Checks if the results dict is accurate even in a 2D plane
-    result = test_info["test6"]["result"]
+    uiManager.change_UI("Startv2")  # change to appropriate UI
+    eventList = get_keydown_event("d")    # Move right once
+    uiManager.draw_UI(eventList)
+    eventList = get_keydown_event("s")    # move down once
+    uiManager.draw_UI(eventList)
+    eventList = get_keydown_event("enter")  # press enter once
+    result = uiManager.draw_UI(eventList)  # save result
     assert result[0] == "Startv2" and result[1] == "Optionsv2"
 
 # Checks if we can set the UI to None safely

--- a/script
+++ b/script
@@ -12,10 +12,7 @@ case $args in
     ;;
 
   run-tests)
-    mkdir -p testDetails  # Make a directory to hold the test information
-    python scripts.py run-tests  # Run the python script to get the test data
-    pytest managers              # Run Pytests
-    rm -rf ./testDetails  # remove the directory and it's contents
+    pytest managers
     ;;
 esac
 


### PR DESCRIPTION
### Pygame-RPG 10.3 Housekeeping and bigfixing
This commit enhances the cursor movement by using the Pygame event Queue instead of using the `game.key.get_pressed()` command. This lets the system 'chain' inputs in a smooth manner thus eliminating the requirement for a time delay in the code. The code that handles processing the events does break when the player enters 'enter' or 'esc' because those keys can trigger a change in UI.

The tests in Dialogue_Manager_test.py were also changed to reflect the new event queue system. All instances of the `ensure_pressed()` command has been replaced with a new command called `get_keydown_event()`. This command takes in a string key and returns an event queue that involves a created a Keydown event based on the inputed key. example, inputting "w" gives a Keydown event with a key value of `game.K_UP`  in the returned event queue.

As a result of these changes, the script files run-tests flag has been modified to only run the `pytest managers` command. This is because, in the advent of these changes, it is no longer required to create a file containing the test data. Incidently, the `run-tests` flag has been removed from the Scripts.py file since it is now unnecessary.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 