### PR TITLE
Pygame-RPG 11 Creation of UIHandler

### DIFF
--- a/managers/Save_Manager.py
+++ b/managers/Save_Manager.py
@@ -107,7 +107,7 @@ class SaveManager:
             print("Invalid file")
 
     def load(self, slot=int):
-        if slot <= self.limit and slot > 0:
+        if slot <= self.limit and slot > 0:  # Verifies if the file exists
             file = open("save/save_data" + str(slot) + ".json", "r")
             self.load_data(file)
         else:

--- a/managers/Save_Manager_test.py
+++ b/managers/Save_Manager_test.py
@@ -117,7 +117,7 @@ def test_quick_load():
 
 animationTracker = random.randint(1, 100)
 animationTracker2 = random.randint(1, 100)
-animationTracker3 = random.randint(1, 100)
+animationTracker3 = random.randint(1, 39)  # Changed to stop the possibility of crash when looking for chest ani
 dialogueTimer = random.randint(1, 180)
 gameState = random.randint(1, 5)
 for i in range(random.randint(1, 10)):

--- a/managers/Screen_Manager.py
+++ b/managers/Screen_Manager.py
@@ -25,7 +25,8 @@ class Event:
 chestB1 = Event((500, 600), "Chest")
 screen_dict = {("Background1", 1): "Background2", ("Background2", -1): "Background1"}
 background_dict ={"Background1": "Background_Art/gothic_chapel_portfolio_1422x800.png",
-                  "Background2": "Background_Art/PNG/game_background_1/game_background_1.png"}
+                  "Background2": "Background_Art/PNG/game_background_1/game_background_1.png",
+                  "Start": "UI/Start.png"}
 interactables_dict = {"Background1": (chestB1, ), "Background2": ()}   # NEEDS TO BE SAVED
 objects_dict = {"Background1": ((800, 500), True), "Background2": ()}  # NEEDS TO BE SAVED
 

--- a/managers/UI_Handler.py
+++ b/managers/UI_Handler.py
@@ -1,0 +1,76 @@
+import os.path
+
+import managers.Save_Manager
+import managers.UI_Manager
+
+# Class that handles the UI inputs
+
+# For UIManager
+ui_related_context = [("Start", "Load Game")]  # Pages who's options go to another UI
+screen_flow_dict = {}
+
+# For SaveManager
+save_related_context = ["Save Game", "Load Game"]
+
+# for Knight
+knight_related_context = []
+
+# for localVars
+vars_related_context = [("Start", "Start Game"), ("Start", "Continue")]
+
+# Battle related context
+battle_related_context = []
+class UIHandler():
+    # The things UIHandler will need access to for user input
+    def __init__(self, UIManager, SaveManager, knight, localVars, battleManager=None):
+        # Dialogue Manager might have to be here too
+        self.UIManager = UIManager  # For changing the UI
+        self.saveManager = SaveManager  # For saving and loading on UI
+        self.knight = knight  # For access to inventory as well as battle interaction
+        self.localVars = localVars  # For manipulating variables from player interaction
+        # Local vars exists in SaveManager, might just reference that one instead
+        self.battleManager = battleManager  # For passing the manager player choice and target
+    # Main function of the class
+    # Takes in the context and the choice that was made and process it
+    def handle_interaction(self, context, choice):
+        if context is not None and choice is not None:
+            #print(context)
+            #print(choice)
+            #print("..........................................")
+            if (context, choice) in ui_related_context:
+                self.UIManager.change_UI(choice)  # Just change to the new UI
+                pass
+
+            elif context in save_related_context:
+                slot = choice.find("#")       # Finds the # character because the number is always next to it
+                slot = int(choice[slot + 1])  # Finds the slot that the user chose
+                if context == "Save Game":
+                    self.saveManager.save(slot)
+                else:
+                    filePath = "save/save_data" + str(slot) + ".json"
+                    if os.path.isfile(filePath):
+                        self.saveManager.load(slot)
+                        self.localVars.update({"start": False})  # Leave the Start screen (probably a better way for this)
+                        self.UIManager.change_UI(None)  # Clear UI
+                # self.saveManager
+                pass
+            elif context in knight_related_context:
+                #self.knight
+                pass
+            elif context in battle_related_context:
+                #self.battleManager
+                pass
+            elif (context, choice) in vars_related_context:  # For now
+                # There's got to be a better way of dealing with this
+                if context == "Start" and choice == "Start Game":
+                    self.localVars.update({"start": False})
+                    self.UIManager.change_UI(None)  # Clear UI
+                elif context == "Start" and choice == "Continue":
+                    slot = self.saveManager.saveNumber
+                    # Implement a check to see if save has been tampered with for all save file loads
+                    flag = os.path.getsize("Save/save_data" + str(slot) + ".json") > 0
+                    if flag:
+                        self.saveManager.quick_load()  # Load the file
+                        self.localVars.update({"start": False})  # Leave the Start screen
+                        self.UIManager.change_UI(None)  # Clear UI
+                    pass

--- a/managers/UI_Handler_test.py
+++ b/managers/UI_Handler_test.py
@@ -1,0 +1,63 @@
+import managers
+import pygame as game
+from managers.UI_Manager_test import get_keydown_event
+
+game.init()
+
+font = game.font.Font('font/Pixeltype.ttf', 50)
+screen = game.display.set_mode((1422, 800))
+
+# Initializing things
+screenManager = managers.ScreenManager(screen)
+dummyKnight = managers.Knight()
+saveManager = managers.SaveManager(dummyKnight, vars(), screenManager)
+UIManager = managers.UIManager(font, screen)
+UIHandler = managers.UIHandler(UIManager, saveManager, dummyKnight, vars())
+
+# Variables I need for save manager
+start = True  # same as the variable that depends
+animationTracker = 0
+animationTracker2 = 0
+animationTracker3 = 0
+gameState = ""
+x = 0
+x = 0
+
+def test_simulate_start_screen():
+    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    UIHandler.handle_interaction(context, choice)
+    # Start should be false and UIManager vars should be cleared
+    assert not start and UIManager.UI is None and len(UIManager.prevUIs) == 0 and choice == "Start Game"
+
+def test_simulate_continue_selection():
+    UIHandler.localVars.update({"start": True})  # Reset start to true
+    UIManager.change_UI("Start")  # Reset UIManager
+    UIManager.draw_UI(get_keydown_event("s"))        # Move down 1
+    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    UIHandler.handle_interaction(context, choice)
+    assert not start and UIManager.UI is None and len(UIManager.prevUIs) == 0 and choice == "Continue"
+
+def test_simulate_move_to_load_screen():
+    UIManager.change_UI("Start")  # Reset UIManager
+    UIManager.draw_UI(get_keydown_event("s"))        # Move down 1
+    UIManager.draw_UI(get_keydown_event("s"))        # Move down 1
+    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    UIHandler.handle_interaction(context, choice)
+    #  UI should change and the previous UI is added to prevUIs
+    assert UIManager.UI == "Load Game" and len(UIManager.prevUIs) > 0 and UIManager.prevUIs[0] == "Start"
+
+def test_simulate_load_fail():
+    # Assume slot 2 is empty
+    UIHandler.localVars.update({"start": True})  # Reset start to true
+    UIManager.draw_UI(get_keydown_event("s"))    # Move down 1
+    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    UIHandler.handle_interaction(context, choice)
+    assert start and UIManager.UI == "Load Game"  # We haven't moved screens and start isn't switched off
+
+def test_simulate_load_success():
+    # Assume slot 1 isn't empty since save manager tests should fill it
+    UIManager.draw_UI(get_keydown_event("w"))        # Move up 1
+    context, choice = UIManager.draw_UI(get_keydown_event("enter"))    # Press enter
+    UIHandler.handle_interaction(context, choice)
+    assert not start and UIManager.UI is None  # Load Succeeds
+

--- a/managers/UI_Manager.py
+++ b/managers/UI_Manager.py
@@ -12,8 +12,8 @@ from managers.UI_Manager_draw import *
 # Options (Not sure if I'll add this part)
 
 # Dictionaries for the titles of games
-title_dict = {"Start": "Legend of Zeroes, Trails of Cold Meals", "Load Game": "Choose Your Save File"}
-title_location_dict = {"Start": (200, 200), "Load Game": (350, 50)}
+title_dict = {"Start": "Legend of Zeroes, Trails of Cold Meals", "Load Game": "Load Game"}
+title_location_dict = {"Start": (200, 200), "Load Game": (550, 50)}
 # Displayables is only for displayable text. Not UI assets
 displayables = {"Start": ("Start Game", "Continue", "Load Game"), "Startv2": ("Start Gamev2", "Continuev2", "Load Gamev2", "Optionsv2"),
                 "Load Game": ("Save Slot #1", "Save Slot #2", "Save Slot #3", "Save Slot #4")}
@@ -116,6 +116,8 @@ class UIManager:
             # Only exception is when we pass null to get rid of UI
             if self.UI is not None and flag:  # flag determines if a page is added to stack
                 self.prevUIs.append(self.UI)
+            if UI is None:
+                self.prevUIs.clear()  # Clear the prev UIs
             self.UI = UI
             self.displayable = displayables.get(self.UI)
             self.constraint_x = constraints_x.get(self.UI)
@@ -162,11 +164,13 @@ class UIManager:
     # Funtion that handles the position of the cursor
     def handle_cursor(self, keys):
         flag = self.cursor.handle_cursor(keys)
+        result = None, None
         # If a selection is made, find out which option was selected
         if flag is None:
             # Return to the previous UI if the array contains an item
             if len(self.prevUIs) != 0:  # Technically speaking this can be simplified to if self.prevUIs
                 self.change_UI(self.prevUIs.pop(), False)  # Setting flag to false means don't add to stack
+
         elif flag:
             pos = self.cursor.pos
             if self.spacing_x != 0:
@@ -188,11 +192,11 @@ class UIManager:
                 # If there's no x spacing then only y spacing matters
                 listPos = ((pos[1] - self.cursor.yConstraints[0]) / self.spacing_y)
             item = self.displayable[int(listPos)]
-            return [self.UI, item]
+            result = self.UI, item
         else:
             self.screen.blit(self.cursor.cursor, self.cursor.pos)
-            return None
 
+        return result
     def draw_menu_and_assets(self, assets):
         # Draw the remaining information
         function = draw_function_dict.get(self.UI)

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -6,3 +6,5 @@ from managers.Dialogue_Manager import DialogueManager
 from managers.Save_Manager import SaveManager
 from managers.UI_Manager import UIManager
 from managers.UI_Manager_draw import *
+from managers.UI_Handler import UIHandler
+from managers.UI_Manager_test import get_keydown_event

--- a/save/save_data1.json
+++ b/save/save_data1.json
@@ -1,25 +1,25 @@
 {
    "Knight": {
-      "Hp": 251,
+      "Hp": 451,
       "Hpcap": 1,
       "Name": "Rion",
-      "Lvl": 6,
-      "Str": 151,
-      "Vit": 51,
-      "Agl": 101,
+      "Lvl": 10,
+      "Str": 271,
+      "Vit": 91,
+      "Agl": 181,
       "Status": "Normal",
       "Stance": "1",
-      "Defence": 151,
+      "Defence": 271,
       "Exp": 0,
-      "Expcap": 501,
+      "Expcap": 901,
       "Bal": 1
    },
    "rawVariables": {
-      "animationTracker": 80,
-      "animationTracker2": 78,
-      "animationTracker3": 84,
+      "animationTracker": 44,
+      "animationTracker2": 60,
+      "animationTracker3": 13,
       "gameState": 4,
-      "x": -59
+      "x": 839
    },
    "screenManager": {
       "context": "Background1",

--- a/save/save_data4.json
+++ b/save/save_data4.json
@@ -1,25 +1,25 @@
 {
    "Knight": {
-      "Hp": 251,
+      "Hp": 451,
       "Hpcap": 1,
       "Name": "Rion",
-      "Lvl": 6,
-      "Str": 151,
-      "Vit": 51,
-      "Agl": 101,
+      "Lvl": 10,
+      "Str": 271,
+      "Vit": 91,
+      "Agl": 181,
       "Status": "Normal",
       "Stance": "1",
-      "Defence": 151,
+      "Defence": 271,
       "Exp": 0,
-      "Expcap": 501,
+      "Expcap": 901,
       "Bal": 1
    },
    "rawVariables": {
-      "animationTracker": 80,
-      "animationTracker2": 78,
-      "animationTracker3": 84,
+      "animationTracker": 44,
+      "animationTracker2": 60,
+      "animationTracker3": 13,
       "gameState": 4,
-      "x": -59
+      "x": 839
    },
    "screenManager": {
       "context": "Background1",


### PR DESCRIPTION
### Pygame-RPG 11 Creation of UIHandler
This Commit focuses on creating the UIHandler class which handles the interactions the player has with the UI and translates those choices to actions taken in the game. As a result, the UIHandler class takes holds a reference to various Manager objects in order to do this.

Objects UIHandler has a reference to:
- UIManager: For operations involving moving from one UI to the next based on player choice.

- SaveManager: For Save and Load operations done by the player.

- Knight: Not in use for now but for the sake of item use and battles this reference may be used.

- localVars: Some UI Interactions require that local variables be changed as a result. Example, setting the `start` variable to false once the player chooses an action that would make them leave the start screen.

- BattleManager: A not yet implemented class but since BattleManager will have a UI component this is neccesary.

The UIHandler class works as follows. The classes' main function is the `handle_interaction()` function which takes in a context and choice gotten from UIManager and processes the action required for that specific context and choice. These actions range from changing the UI to directly manipulating local variable values. As always, a file testing the utility of the UIHandler class was created.

This commit also aims to integrate the UIManager and UIHandler classes into the Rpg2.py file so that they can be play tested. As a result, there is a starting loop that depends on the `start` boolean variable that sets the UI to the start screen and forces the player to stay there until they pick a choice that switches `start` to false. If the 'start' variable is switched to false because of the choice 'Start Game' then the screenManager context is manually changed, or else it will be handled by the load operation the player chose.

Some behavioral changes were also made to certain files, the changes were the following.

- UIManager's title for the 'Load Game' UI is changed to 'Load Game' and it's position was adjusted accordingly

- If None is passed to `UIManager.change_UI()` the object will be 'cleared'

- `Save_Manager_test.py` had the range of it's random value for animationTracker3 reduced since it was possible to get an invalid number for this stage of development

- As a result of the 'invalid number' problem mentioned earlier, the `save_data.json` files were updated with non-problematic files. I do find it weird how this bug just started happening now though... It could have just been blind luck though.

### Side Note
It is wholly possible that in the future UIHandler will need a reference to DialogueManager as well for NPC interactions. I'm still considering how I'll deal with that.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 