### PR TITLE
Pygame-RPG 14 Creation of BattleManager class

### DIFF
--- a/Entity/Battle_Manager.py
+++ b/Entity/Battle_Manager.py
@@ -1,0 +1,178 @@
+import random
+import json
+from Entity.Move import Move
+
+class BattleManager:
+    def __init__(self, knight):
+        self.moveDict = self.get_move_dict()
+        self.hero = knight
+        self.enemies = []  # tuple dict with enemy object and the x and y position of the object
+        self.turnOrder = []  # turn order list for the entities
+        self.lootPool = {
+            "Exp": 0,
+            "Money": 0,
+            "Items": {
+
+            }
+        }
+
+    def get_move_dict(self):
+        # Loads the move dictionary from a file
+        file = open("JSON/Moves/Complete_Move_List.json", "r")
+        jsonInfo = json.load(file)
+        file.close()
+        return jsonInfo
+
+    def do_battle(self):
+        # I'll worry about the drawing later
+        # One round of battle
+        turnObject = self.turnOrder.pop(0)  # Get the first index object
+        objectType = turnObject.__class__.__name__
+
+        if objectType == "Knight":
+            # let the player control the object
+            pass
+        else:
+            usable = False
+            loopNum = 0
+            moveObj = Move(turnObject, self.moveDict["Attack"])
+            while not usable and loopNum < 20:
+                moveNum = random.randint(0, (len(turnObject.moveList) - 1))
+                move = turnObject.moveList[moveNum]
+                weightNum = random.randint(0, 100)
+                moveInfo = self.moveDict[move]
+                if weightNum <= moveInfo["Weight"] and self.parse_restriction(turnObject, moveInfo)\
+                        and turnObject.Mp >= moveInfo["Cost"]:
+                    usable = True
+                    moveObj = Move(turnObject, moveInfo)
+                loopNum += 1
+            self.use_move(turnObject, moveObj, self.hero)
+
+
+
+    def use_move(self, turnObject, move,  *targets):
+        effectList = self.parse_effects(move)  # the function null checks the effects of the move
+        for i in range(len(targets)):
+            turnObject.Mp -= move.cost  # lower Mp by the cost of the move
+            if move.type == "Attack":  # if this move is an attack, do damage to the target object
+                objectType = targets[i].__class__.__name__
+                if objectType == "Knight":
+                    targets[i].take_damage(move.damage)
+                else:
+                    targets[i].take_attack(move.damage, self.lootPool)
+            self.apply_effects(effectList, turnObject, targets[i])
+
+
+
+    def parse_effects(self, move):
+        effectList = []
+        if move is not None and move.effect is not None:
+            effects = move.effect.split(",")
+
+            if len(effects) % 2 == 0:
+                # immediate effect
+                for i in range(0, len(effects), 2):
+                    effect = effects[i]
+                    target = effects[i + 1].strip()
+                    effectList.append((target, effect))
+
+            elif len(effects) % 3 == 0:
+                # Debuff/buff effect
+                for i in range(0, len(effects), 3):
+                    buffAndStat = effects[i].split()
+                    buff = int(buffAndStat[i])
+                    stat = buffAndStat[i + 1]
+                    target = effects[i + 1].strip()
+                    buff = {stat: (buff, int(effects[i + 2]))}
+                    effectList.append((target, buff))  # tuple with target and the buff
+        return effectList
+
+    def apply_effects(self, effectList, turnObject, target):
+        for i in range(len(effectList)):
+            currentEffectTup = effectList[i]
+            targetIndicator = currentEffectTup[0]
+            if targetIndicator == "T":
+                effectTarget = target
+            else:
+                effectTarget = turnObject
+            effect = currentEffectTup[1]
+            if effect.__class__ == str:
+                effectSplit = effect.split()
+                try:
+                    # do if the first string is a number
+                    # this is a bad idea waiting to happen
+                    # checks need to be added
+                    num = int(effectSplit[0])
+                    stat = effectSplit[1]
+                    effectTarget.__dict__[stat] += num
+                except:
+                    # if the first string isn't a number then do other things
+                    # Assume it is applying a status or something
+                    word = effectSplit[0]  # Word determines what gets done
+                    result = effectSplit[1]
+                    if word == "Apply":
+                        # Apply a status effect
+                        pass
+            else:
+                # Debuff/buff
+                self.apply_effect_buff(effectTarget, effect)
+    def apply_effect_buff(self, target, buff):
+        target.remove_bonuses(False)  # strip off bonuses but don't remove buffs
+        target.Bonuses.update(buff)  # Overwrite the buffs
+        target.apply_bonuses(False)  # re-apply the bonuses but don't lower turn count
+
+    def parse_restriction(self, entity, moveInfo):
+        # parses the requirement and returns a boolean
+        flag = True
+        restriction = moveInfo["Restriction"]  # gets the restriction value
+        if restriction is not None:  # None check
+            restriction = restriction.split()
+            stat = entity.__dict__[restriction[0]]
+            operator = restriction[1]
+            condition = restriction[2]
+            hasPercentage = (condition.find("%") != -1)
+            if isinstance(stat, str):
+                flag = stat == condition
+            else:
+                if hasPercentage:
+                    # converts the percentage to a real number (only usable by Hp and Mp stats)
+                    condition = entity.__dict__[restriction[0] + "cap"] * (int(condition[0: len(condition) - 1]) / 100)
+                if operator == "<" and isinstance(stat, int):
+                    flag = stat < int(condition)
+
+                elif operator == ">" and isinstance(stat, int):
+                    flag = stat > int(condition)
+        return flag
+
+    def reset_turn_order(self):
+        if len(self.turnOrder) == 0:
+            # add the hero object to the turn order with the agility stat as the first index of the tuple
+            self.turnOrder.append((self.hero.Agl, self.hero))
+            # add the enemy objects to the turn order with the agility stat as the first index of the tuple
+            for i in range(len(self.enemies)):
+                enemy = self.enemies[i]
+                self.turnOrder.append((enemy.Agl, enemy))
+            # sort the list, since the tuple has a number in the first index in descending order
+            self.turnOrder.sort(reverse=True)
+        # loop through the turn order and replace each index with the Entity object
+            for i in range(len(self.turnOrder)):
+                tup = self.turnOrder[i]
+                self.turnOrder[i] = tup[1]
+
+
+    def clear_dead_enemies(self):
+        newEnemies = []  # empty list of enemies that aren't dead
+        newTurnOrder = []  # empty list of entities that aren't dead
+        # Loop through enemies list and append the not dead enemies to the newEnemies list
+        for i in range(len(self.enemies)):
+            enemy = self.enemies[i]
+            if enemy.Status != "Dead":
+                newEnemies.append(enemy)
+        self.enemies = newEnemies  # set the enemies list to the newEnemies list
+        # Loop through the turnOrder list and append the not dead entities to the newTurnOrder list
+        for i in range(len(self.turnOrder)):
+            enemy = self.turnOrder[i]
+            if enemy.Status != "Dead":
+                newTurnOrder.append(enemy)
+        self.turnOrder = newTurnOrder  # set the turnOrder list to the newTurnOrder list
+

--- a/Entity/Battle_Manager_test.py
+++ b/Entity/Battle_Manager_test.py
@@ -1,0 +1,93 @@
+from Entity.Knight import Knight
+from Entity.Entity_Factory import EntityFactory
+from Entity.Battle_Manager import BattleManager
+from Entity.Move import Move
+
+factory = EntityFactory()
+knight = Knight()
+dummy = factory.create_entity("dummy")
+battleManager = BattleManager(knight)
+battleManager.enemies.append(dummy)
+effectListMatrix = []
+# creating move objects
+attack = Move(dummy, battleManager.moveDict["Attack"])
+buffEffectMove = Move(dummy, battleManager.moveDict["Angry Shout"])
+immediateMove = Move(dummy, battleManager.moveDict["Pilfering Strike"])
+healMove = Move(dummy, battleManager.moveDict["Drink Potion"])
+
+def test_parse_effects():
+    # parse a move with no effect
+    effectListMatrix.append(battleManager.parse_effects(attack))
+    flag = len(effectListMatrix[0]) == 0
+    # parse the effects of a move with a buff effect
+    effectListMatrix.append(battleManager.parse_effects(buffEffectMove))
+    # check if the target is correct and check if the second index of the tuple is of the correct type
+    flag2 = effectListMatrix[1][0][0] == "S" and isinstance(effectListMatrix[1][0][1], dict)
+    # parse the effects of a move with an immediate effect
+    effectListMatrix.append(battleManager.parse_effects(immediateMove))
+    # check if the target is correct and check if the second index of the tuple is of the correct type
+    flag3 = effectListMatrix[2][0][0] == "T" and isinstance(effectListMatrix[2][0][1], str)
+    effectListMatrix.append(battleManager.parse_effects(healMove))  # add the heal move effect list for later test
+    # Check the flags
+    assert flag and flag2 and flag3
+
+
+def test_apply_effect_buff():
+    strBuff = (100, 0)
+    aglBuff = (30, 3)
+    defBuff = (50, 3)
+    # Add the buffs to the dummy object
+    dummy.Bonuses.update({"Str": strBuff})
+    dummy.Bonuses.update({"Agl": aglBuff})
+    # call the apply_effect_buff function
+    battleManager.apply_effect_buff(dummy, {"Defence": defBuff})
+    # Checks if the defence buff was successfully applied
+    # Check if the buffs that were applied before are still applied after the apply_effect_buff() call
+    # This implicitly checks if the turn counts were altered
+    assert dummy.Bonuses["Str"] == strBuff and dummy.Bonuses["Agl"] and dummy.Bonuses["Defence"] == defBuff
+
+def test_apply_effects():
+    knight.Bal = 20  # setting knight Bal attribute
+    oldDummyHp = dummy.Hp  # saving the dummy's Hp before it is changed by effect
+    for i in range(len(effectListMatrix)):
+        effectList = effectListMatrix[i]  # gets the current effect list
+        battleManager.apply_effects(effectList, dummy, knight)  # run apply_effects()
+    # Check if all the effects were properly applied
+    assert dummy.Bonuses["Str"] == (5, 3) and knight.Bal == 0 and oldDummyHp + 20 == dummy.Hp
+
+def test_use_move():
+    # Buffing knight object's stats, so they survive the dummy object's attack
+    knight.Bal = 20  # give knight 20 dollar for him to get robbed again
+    knight.Hp = 999
+    knight.Hpcap = 999
+    knight.Defence = 700
+    battleManager.use_move(dummy, attack, knight)  # this should do exactly 99 damage
+    battleManager.use_move(dummy, buffEffectMove, knight)
+    battleManager.use_move(dummy, immediateMove, knight)  # this should do 0 damage because of knight's defence
+    battleManager.use_move(dummy, healMove, knight)
+    # check if the knight's attributes to see if they're affected, check if the dummy's Mp decreased
+    assert knight.Bal == 0 and knight.Hp == 900 and dummy.Mp == dummy.Mpcap - 120
+
+def test_parse_restrictions():
+    # NEEDS MORE TEST CASES
+    # see if the dummy can use the move
+    flag = battleManager.parse_restriction(dummy, battleManager.moveDict["Wrathful Charge"])
+    dummy.Hp = int(dummy.Hpcap * .20)  # lower dummy object's Hp to meet the threshold
+    # see if the dummy can use the move again with lower health
+    flag2 = battleManager.parse_restriction(dummy, battleManager.moveDict["Wrathful Charge"])
+    # see if the dummy can use a move that has no restriction
+    flag3 = battleManager.parse_restriction(dummy, battleManager.moveDict["Attack"])
+    # check the flags
+    assert not flag and flag2 and flag3
+
+def test_reset_turn_order():
+    battleManager.reset_turn_order()  # call reset turn order
+    # check if the turnOrder list has the proper length and the proper position for the objects
+    assert (len(battleManager.turnOrder) == 2 and battleManager.turnOrder[0] == dummy
+            and battleManager.turnOrder[1] == knight)
+
+def test_clear_dead_enemies():
+    battleManager.enemies[0].Status = "Dead"  # Change Dummy status to Dead
+    battleManager.clear_dead_enemies()  # clear the dead enemies
+    # Check if the enemies list is empty and only the hero object should be in turn order now
+    assert len(battleManager.enemies) == 0 and len(battleManager.turnOrder) == 1

--- a/Entity/Enemy.py
+++ b/Entity/Enemy.py
@@ -2,10 +2,11 @@ from Entity.Entity import Entity
 
 class Enemy(Entity):
     def __init__(self, jsonInfo):
-        Entity.__init__(self, jsonInfo["Hp"], jsonInfo["Hpcap"], jsonInfo["Name"],
+        Entity.__init__(self, jsonInfo["Hp"], jsonInfo["Hpcap"], jsonInfo["Mp"], jsonInfo["Mpcap"], jsonInfo["Name"],
                         jsonInfo["Lvl"], jsonInfo["Str"], jsonInfo["Vit"],
                         jsonInfo["Agl"], jsonInfo["Defence"], jsonInfo["Exp"], jsonInfo["Money"],
                         jsonInfo["Inventory"])
+        self.moveList = jsonInfo["moveList"]
         self.uniqueBuff = jsonInfo["uniqueBuff"]  # For bosses only really
         self.weakness = jsonInfo["Weakness"]  # What stance they're weak to
 

--- a/Entity/Entities_test.py
+++ b/Entity/Entities_test.py
@@ -9,13 +9,11 @@ lootpool = {"Exp": 0, "Money": 0, "Items": {}}
 # Entity method tests
 ################################################################
 
-def test_attack():  # Method hasn't been written yet so it cannot be tested
-    pass
 
 def test_take_damage():
     mockEnemy.take_damage(-900)
     flag = mockEnemy.Hp == mockEnemy.Hpcap  # Hp shouldn't change
-    mockEnemy.take_damage(999)
+    mockEnemy.take_damage(9999)
     assert flag and mockEnemy.Hp == 0 and mockEnemy.Status == "Dead"
 
 def test_apply_bonuses():

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -1,11 +1,13 @@
 # Parent class of hero and monster classes. Saves me the trouble of re-writing a
 # bunch of code
 class Entity:
-    def __init__(self, Hp, Hpcap, name, level, strength, vitality, agility, defence, exp, money, inventory=None):
+    def __init__(self, Hp, Hpcap, Mp, Mpcap, name, level, strength, vitality, agility, defence, exp, money, inventory=None):
         if inventory is None:
             inventory = {}  # Inventory is a dictionary of it with key pairs (string: int)
         self.Hp = Hp
         self.Hpcap = Hpcap
+        self.Mp = Mp
+        self.Mpcap = Mpcap
         self.Name = name
         self.Lvl = level
         self.Str = strength
@@ -15,14 +17,11 @@ class Entity:
         self.Bonuses = {  # A dict of all positive and negative effects on Knight character, includes stance bonuses
             "Str": (0, -1), "Vit": (0, -1), "Agl": (0, -1), "Defence": (0, -1)  # -1 means unlimited duration for bonus
         }
-        self.moveSet = []
         self.Defence = defence
         self.Exp = exp
         self.Bal = money
         self.Inventory = inventory  # For heroes, it's a bunch of useful items, for monsters it's dropped items
 
-    def attack(self, target):  # Write later
-        pass
 
     def take_damage(self, damage):
         damage = damage - self.Defence  # how much damage you ACTUALLY take
@@ -32,7 +31,8 @@ class Entity:
                 self.Hp = 0  # Set hp to 0 or else weird things will start happening
                 self.Status = "Dead"  # Change status to dead
 
-    def apply_bonuses(self):
+    def apply_bonuses(self, flag=True):
+        # flag being False stops the turn count from lowering
         # applies the bonus to the relevant stat
         # Only one bonus can be applied to a stat at a time leading to some interesting strats...
         knightDict = self.__dict__  # This is a horrible idea... still doing it
@@ -40,15 +40,22 @@ class Entity:
             bonus = bonusInfo[0]
             turnCount = bonusInfo[1]
             knightDict.update({stat: knightDict[stat] + bonus})
-            if turnCount != -1:  # If it isn't an infinite buff then decrement counter
+            if turnCount != -1 and flag:  # If it isn't an infinite buff then decrement counter
                 self.Bonuses.update({stat: (bonus, turnCount - 1)})  # Add the updated turn count to bonuses dict
 
-    def remove_bonuses(self):
+    def remove_bonuses(self, flag=True):
+        # flag being False stops the removal of buffs
         # Removes any buff effect at the end of turn so buff effects don't linger
         knightDict = self.__dict__  # This is a horrible idea... still doing it
         for stat, bonusInfo in self.Bonuses.items():
             bonus = bonusInfo[0]
             turnCount = bonusInfo[1]
             knightDict.update({stat: knightDict[stat] - bonus})  # Resetting the stat to it's initial value
-            if turnCount == 0:  # Removes buffs from bonuses if it's turnCount has reached 0
+            if turnCount == 0 and flag:  # Removes buffs from bonuses if it's turnCount has reached 0
                 self.Bonuses.update({stat: (0, -1)})  # Reset the buff entry to default value
+
+    def correct_stats(self):
+        if self.Hp > self.Hpcap:
+            self.Hp = self.Hpcap
+        if self.Bal < 0:
+            self.Bal = 0

--- a/Entity/Knight.py
+++ b/Entity/Knight.py
@@ -13,14 +13,13 @@ inventory = []
 # Statuses: Normal or In-Combat or Dead or opening_chest
 class Knight(Entity):
     # The current stats still need to be changed to the default stats later
-    def __init__(self, Hp=1, HPcap=1, name="Rion", level=1, strength=1, vitality=1, agility=1, defence=1, exp=0, expcap=1, money=0):
-        Entity.__init__(self, Hp, HPcap, name, level, strength, vitality, agility, defence, exp, money)
-        self.Mp = 1     # deal with this later when you're doing battle manager
-        self.Mpcap = 1  # deal with this later when you're doing battle manager
+    def __init__(self, Hp=1, HPcap=1, Mp=1, Mpcap=1, name="Rion", level=1, strength=1, vitality=1, agility=1, defence=1, exp=0, expcap=1, money=0):
+        Entity.__init__(self, Hp, HPcap, Mp, Mpcap, name, level, strength, vitality, agility, defence, exp, money)
         self.Expcap = expcap
         self.Stance = "1"
         self.growths = {"Hpcap": self.Vit * 1 + 50, "Str": self.Str * 1 + 50, "Vit": self.Vit * 1 + 50,
                         "Agl": self.Agl * 1 + 50, "Defence": self.Defence + 50}
+        self.moveList = ["Attack"]
 
     def level_up(self):
         # add to stats

--- a/Entity/Move.py
+++ b/Entity/Move.py
@@ -1,0 +1,25 @@
+
+class Move:
+    def __init__(self, entity, jsonInfo):
+        self.damage = parse_damage_calculation(jsonInfo["Damage Calculation"], entity)  # Damage the move does
+        self.type = jsonInfo["Type"]  # The type of move in question
+        self.cost = jsonInfo["Cost"]  # The Mp cost of the move
+        self.restriction = jsonInfo["Restriction"]  # Conditions that need to be met for the move to be used
+        self.effect = jsonInfo["Effect"]  # Attached effect of the move
+        self.AOE = jsonInfo["AOE"]  # boolean value that mentions if the move targets the entire screen
+        self.targetNumber = jsonInfo["Target Number"]  # Integer representing the amount of targets for the given move
+        # Chance for the effect of a move to be applied
+        self.probability = jsonInfo["Probability"]
+        self.weight = jsonInfo["Weight"]  # Probability of the move being used (Enemy object only)
+        self.description = jsonInfo["Description"]  # Description of the attack being used
+    
+
+def parse_damage_calculation(damageFormula, entity):
+    # Function that interprets the string as a simple math formula
+    # Need to make this more advanced later
+    damage = 0
+    parseableText = damageFormula.split()
+    if len(parseableText) == 3:
+        stat = entity.__dict__[parseableText[0]]  # Grabbing the int value of the stat from entity
+        damage = stat * float(parseableText[2])  # Calculating what the damage is going to be
+    return int(damage)

--- a/Entity/__init__.py
+++ b/Entity/__init__.py
@@ -3,3 +3,4 @@ from Entity.Enemy import Enemy
 from Entity.Knight import Knight
 from Entity.Entity import Entity
 from Entity.Entity_Factory import EntityFactory
+from Entity.Move import Move

--- a/JSON/Enemies/Goblin.json
+++ b/JSON/Enemies/Goblin.json
@@ -1,6 +1,8 @@
 {
    "Hp": 1,
    "Hpcap": 1,
+   "Mp": 1,
+   "Mpcap": 1,
    "Name": "Goblin",
    "Lvl": 1,
    "Str": 1,
@@ -10,6 +12,12 @@
    "Exp": 1,
    "Money": 1,
    "Inventory": {},
+   "moveList": [
+      "Attack",
+      "Pilfering Strike",
+      "Angry Shout",
+      "Drink Potion"
+   ],
    "uniqueBuff": "",
    "Weakness": ""
 }

--- a/JSON/Enemies/Kobold.json
+++ b/JSON/Enemies/Kobold.json
@@ -1,6 +1,8 @@
 {
    "Hp": 1,
    "Hpcap": 1,
+   "Mp": 1,
+   "Mpcap": 1,
    "Name": "Kobold",
    "Lvl": 1,
    "Str": 1,
@@ -10,6 +12,9 @@
    "Exp": 1,
    "Money": 1,
    "Inventory": {},
+   "moveList": [
+      "Attack"
+   ],
    "uniqueBuff": "",
    "Weakness": ""
 }

--- a/JSON/Enemies/dummy.json
+++ b/JSON/Enemies/dummy.json
@@ -1,15 +1,20 @@
 {
-   "Hp": 1,
-   "Hpcap": 1,
+   "Hp": 999,
+   "Hpcap": 999,
+   "Mp": 999,
+   "Mpcap": 999,
    "Name": "dummy",
    "Lvl": 1,
-   "Str": 1,
-   "Vit": 1,
-   "Agl": 1,
+   "Str": 999,
+   "Vit": 999,
+   "Agl": 999,
    "Defence": 1,
    "Exp": 1,
    "Money": 1,
    "Inventory": {"Potion":  1},
+   "moveList": [
+      "Attack"
+   ],
    "uniqueBuff": "",
    "Weakness": ""
 }

--- a/JSON/Moves/Complete_Move_List.json
+++ b/JSON/Moves/Complete_Move_List.json
@@ -1,0 +1,62 @@
+{
+   "Attack": {
+      "Damage Calculation": "Str * 0.8",
+      "Type": "Attack",
+      "Cost": 0,
+      "Restriction": null,
+      "Effect": null,
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": null,
+      "Weight": 100,
+      "Description": "Standard attack, inflicts a normal amount of damage to one enemy."
+   },
+   "Pilfering Strike": {
+      "Damage Calculation": "Str * 0.6",
+      "Type": "Attack",
+      "Cost": 20,
+      "Restriction": null,
+      "Effect": "-20 Bal, T",
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": 50,
+      "Weight": 50,
+      "Description": "A weak attack that has a medium chance of stealing gold from the target."
+   },
+   "Angry Shout": {
+      "Damage Calculation": "",
+      "Type": "Buff",
+      "Cost": 60,
+      "Restriction": null,
+      "Effect": "+5 Str, S, 3",
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": null,
+      "Weight": 50,
+      "Description": "The user howls in anger, raising the strength of the user for 3 turns."
+   },
+   "Drink Potion": {
+      "Damage Calculation": "",
+      "Type": "Heal",
+      "Cost": 40,
+      "Restriction": null,
+      "Effect": "+20 Hp, S",
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": null,
+      "Weight": 25,
+      "Description": "The user drinks a potion and heals 20 Hp."
+   },
+   "Wrathful Charge": {
+      "Damage Calculation": "Str * 2",
+      "Type": "Attack",
+      "Cost": 100,
+      "Restriction": "Hp < 25%",
+      "Effect": null,
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": null,
+      "Weight": 100,
+      "Description": ""
+   }
+}

--- a/Scripts.py
+++ b/Scripts.py
@@ -9,25 +9,29 @@ import json
 game.init()
 
 if __name__ == "__main__":
-    game.init()
-    screen = game.display.set_mode((1422, 800))
-    font = game.font.Font('font/Pixeltype.ttf', 50)
     arg = sys.argv[1]
 
     if arg == "fill-save":
+        game.init()
+        screen = game.display.set_mode((1422, 800))
+        font = game.font.Font('font/Pixeltype.ttf', 50)
         screenManager = ScreenManager(screen)
         knight = Knight()
         saveManager = SaveManager(knight, vars(), screenManager)
         for i in range(4):
             saveManager.save(i+1)
+        game.quit()
+        exit()
 
-    if arg == "create-enemy":
+    elif arg == "create-enemy":
         arg2 = sys.argv[2]  # There will a second argument with this
         path = "JSON/Enemies/" + arg2 + ".json"
         file = open(path, "w")  # Create the JSON file
         enemy_dict = {
             "Hp": 1,
             "Hpcap": 1,
+            "Mp": 1,
+            "Mpcap": 1,
             "Name": arg2,
             "Lvl": 1,
             "Str": 1,
@@ -37,10 +41,34 @@ if __name__ == "__main__":
             "Exp": 1,
             "Money": 1,
             "Inventory": {},
+            "moveList": ["Attack"],
             "uniqueBuff": "",
             "Weakness": ""
         }
         json.dump(enemy_dict, file, indent=3)  # Dump the JSON info
         file.close()  # Close the file
-    game.quit()
-    exit()
+
+    elif arg == "create-move":
+        arg2 = sys.argv[2]  # There will a second argument with this
+        path = "JSON/Moves/Complete_Move_List.json"
+        file = open(path, "r")
+        jsonInfo = json.load(file)
+        file.close()
+        file = open(path, "w")
+        jsonInfo.update({
+            arg2: {
+                "Damage Calculation": "",
+                "Type": "",
+                "Cost": 0,
+                "Restriction": None,
+                "Effect": None,
+                "AOE": False,
+                "Target Number": 1,
+                "Probability": None,
+                "Weight": 100,
+                "Description": ""
+            }
+        })
+        json.dump(jsonInfo, file, indent=3)
+        file.close()
+

--- a/script
+++ b/script
@@ -14,10 +14,22 @@ case $args in
 
   run-tests)
     pytest managers
+    pytest Entity
     ;;
 
   create-enemy)
     python scripts.py create-enemy "$args2"
+    ;;
+
+  refresh-enemy-data)
+    ls JSON/Enemies/ | while read -r FILE
+      do python scripts.py create-enemy "${FILE%.*}"
+    done
+  ;;
+
+  create-move)
+    python scripts.py create-move "$args2"
+
 esac
 
 


### PR DESCRIPTION
### Pygame-RPG 14 Creation of BattleManager class
This commit is the compilation of all of the changes that were done for the sake of the BattleManager class and the Move class. This PR includes changes that directly impact the classes and some miscellaneous changes. The BattleManager class was created for the purpose of managing the fight encounters between Entity objects. The Move class was created to take the structured move data from JSON and turn it into a real object.

To begin with, this PR introduces the Move class. This class takes in an Entity object and the dictionary it needs for it's attributes. It only has one notable function, the `parse_damage_calculation()` function. This function uses the damage formula present in the dictionary to calculate the damage this Move object can do. If there is no damage formula in the dictionary information, the damage is 0.

To begin with, this PR introduces the BattleManager class. This class has the following attributes. `moveDict`, `hero`, `enemies`, `turnOrder` and `lootPool`.

- `moveDict`: A dictionary formed by loading the information from the "JSON/Moves/Complete_Move_List.json" file.

- `hero`: a reference to the Knight object

- `enemies`: A list of enemies for the given combat encounter

- `turnOrder`: a list of Entities in the order in which they can act

- `lootPool`: A dictionary containing all the eperience, money and items the player gains when they win.

The BattleManager class has the following relevant functions. `do_battle()`, `use_move()`, `parse_effects()`, `apply_effects()`, `apply_effect_buff()`, `parse_restriction()`, `reset_turn_order()` and `clear_dead_enemies()`.

`clear_dead_enemies()`: This function iterates through the enemies and turnOrder list and adds the Entity objects that aren't dead to a new list. This effectively removes dead Entity objects from the two lists.

`reset_turn_order()`: This function adds all of the Entity objects in the battle to a list and sorts them based on their Agl stats. This list then becomes the new turnOrder.

`parse_restriction()`: This function takes in an Entity object and a dictionary containing information about the move they want to use. It then uses the restriction string (if there is any) to determine whether the Entity object meets the requirement to use the move by returning a boolean value.

`parse_effects()`: this function take in a Move object. It then uses the `effect` attribute of the object to determine the type of effect that it has. It parses the string (if it's present) and returns a list of tuples containing the effects and their targets in an easier to understand way. If there is no effect, an empty list is returned.

`apply_effect_buff()`: This function takes in a target Entity and a dictionary that describes a buff. To ensure that there is no permanent stat loss or gain, the target's buffs are removed first before the buffs are updated and re-applied. To do this, a False boolean value is passed to the Entity object's `remove_bonuses()` and `apply_bonuses()` function. This flag tells the functions to not remove buffs that have reached the end of their turn count in the case of `remove_bonuses()` and to not lower the turn count of existing buffs when `apply_bonuses()` is used.

`apply_effects()`: This function takes in an effectList, the object whose turn it is and the object this object is targetting. This function iterates through the effectList and parses the curated effects. It first determines who the target of the effect should be by using the value at index 0 of the tupple, it then looks at the class of the value in index 1 of the tupple. If the class is a string then it deals with it in a "try-except" block. If the class is a dictionary then it calls the `apply_effect_buff()` function for the target.

`use_move()`: This function takes in the turnObject, a Move object and a list of targets that the move is to be used on. It gets the effectList from the `parse_effects()` function and then iterates through the list of targets. If the Move object's type attribute is "Attack" then the target takes damage equal to the Move object's damage attribute. Depending on which class the object is part of, the function called for this is different. The effects of the move are then applied.

`do_battle()`: this function pops the object at the 0 index of the turnOrder list. If the object is of the `Knight` class, the player will then have to choose what to do. If not, the enemy randomly determines what move in their movelist will do. There is a failsafe for this where if the enemy fails to land on a usable move 20 times over, the enemy will just attack.

Other Changes:

- The Entity classes init function now includes the Mp and Mpcap stats. As a result the `Enemy` and `Knight` classes needed to change their constructors to accomodate the change.

- the `Attack()` function of the Entity class was removed allowing with any reference to it. Since BattleManager will handle this, this function is useless.

- both the `apply_bonuses()` and `remove_bonuses()` functions for the Entity class now take in an optional flag. If this flag is False, the `apply_bonuses()` function will not decrease the turn count of the buffs applied and the `remove_bonuses()` function will not strip off any buffs that have reached the end of their turn counts.

- `correct_stats()` function for the Entity class has been created for future use. At the moment it simply fixes any stats that have a higher or lower value than what should be possible. This will be called every turn.

- The `Knight` class' moveList attribute starts with the "Attack" value in index 0.

- Changes to the files in the JSON/Enemies directory. Because of this, the Entities_test.py file needed a small change to the damage that was dealt to the dummy object.

- Creation of the JSON/Moves/Complete_Move_List.json file. This file contains the JSON information for every single move that is currently in the game and is read from by the BattleManager class.

- Added pytest Entity folder command to the run-tests option in script file

- added refresh-enemy-data option to script file. This option applies any of the newly made changes to the Scripts.py file's create-enemy option to every file in the JSON/Enemies directory. The bad news is that all data is reset for this

- create-move option added to script file. This simply creates a new Move object JSON schema for me to add move info too.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 