### PR TITLE
Pygame-RPG 15.1 Housekeeping and bugfixing

### DIFF
--- a/Rpg2.py
+++ b/Rpg2.py
@@ -136,8 +136,9 @@ x = 500
 screenManager = managers.ScreenManager(tempScreen)
 dialogueManager = managers.DialogueManager(font, screen)
 saveManager = managers.SaveManager(knight, vars(), screenManager)
+BattleManager = Entity.BattleManager(knight)
 UIManager = managers.UIManager(font, screen)
-UIHandler = managers.UIHandler(UIManager, saveManager, knight, vars())
+UIHandler = managers.UIHandler(UIManager, saveManager, knight, vars(), knight)
 
 interactables = screenManager.interactables
 textEnable = True  # For the purposes of this test

--- a/managers/UI_Manager.py
+++ b/managers/UI_Manager.py
@@ -310,8 +310,8 @@ class UIManager:
         self.screen.blit(smallerSemiCircle, (280, 40))
 
         # drawing values in the health bars
-        hpText = self.font.render(str(knight.Hp)+"/"+str(knight.Hpcap), False, "Black")
-        mpText = self.font.render(str(knight.Mp)+"/"+str(knight.Mpcap), False, "Black")
+        hpText = self.font.render(str(knight.Hp)+"/"+str(knight.Hpcap), False, "White")
+        mpText = self.font.render(str(knight.Mp)+"/"+str(knight.Mpcap), False, "White")
         self.screen.blit(hpText, (200, 15))
         self.screen.blit(mpText, (180, 43))
 

--- a/save/save_data1.json
+++ b/save/save_data1.json
@@ -1,7 +1,9 @@
 {
    "Knight": {
-      "Hp": 451,
-      "Hpcap": 1,
+      "Hp": 500,
+      "Hpcap": 500,
+      "Mp": 39,
+      "Mpcap": 100,
       "Name": "Rion",
       "Lvl": 10,
       "Str": 271,
@@ -17,7 +19,7 @@
    "rawVariables": {
       "animationTracker": 44,
       "animationTracker2": 60,
-      "animationTracker3": 13,
+      "animationTracker3": 0,
       "gameState": 4,
       "x": 839
    },

--- a/save/save_data4.json
+++ b/save/save_data4.json
@@ -1,25 +1,55 @@
 {
    "Knight": {
-      "Hp": 451,
+      "Hp": 1,
       "Hpcap": 1,
+      "Mp": 1,
+      "Mpcap": 1,
       "Name": "Rion",
-      "Lvl": 10,
-      "Str": 271,
-      "Vit": 91,
-      "Agl": 181,
+      "Lvl": 1,
+      "Str": 1,
+      "Vit": 1,
+      "Agl": 1,
       "Status": "Normal",
-      "Stance": "1",
-      "Defence": 271,
+      "Bonuses": {
+         "Str": [
+            0,
+            -1
+         ],
+         "Vit": [
+            0,
+            -1
+         ],
+         "Agl": [
+            0,
+            -1
+         ],
+         "Defence": [
+            0,
+            -1
+         ]
+      },
+      "Defence": 1,
       "Exp": 0,
-      "Expcap": 901,
-      "Bal": 1
+      "Bal": 0,
+      "Inventory": {},
+      "Expcap": 1,
+      "Stance": "1",
+      "growths": {
+         "Hpcap": 51,
+         "Str": 51,
+         "Vit": 51,
+         "Agl": 51,
+         "Defence": 51
+      },
+      "moveList": [
+         "Attack"
+      ]
    },
    "rawVariables": {
-      "animationTracker": 44,
-      "animationTracker2": 60,
-      "animationTracker3": 13,
-      "gameState": 4,
-      "x": 839
+      "animationTracker": 79,
+      "animationTracker2": 332,
+      "animationTracker3": 39,
+      "x": 460
    },
    "screenManager": {
       "context": "Background1",
@@ -41,7 +71,7 @@
                   600
                ],
                "eventType": "Chest",
-               "activated": false,
+               "activated": true,
                "path": ""
             }
          ],


### PR DESCRIPTION
### Pygame-RPG 15.1 Housekeeping and bugfixing
This commit fixes the save files, Rpg2.py file as well as the changing the color for the health and mana bar text.

The save files were outdated due to the addition of the addition of the `Mp` and `Mpcap` attributes being added to the Knight object. As a result, this broke the old save files. This escaped automated testing because the Dummy_Knight.py file did not have these changes. A fix for Dummy_Knight.py will happen in the future. I also took the time to change up the health and mana values to see what they would look like on screen.

Rpg2.py now needed the addition of the BattleManager class since the UIHandler class now needs it in it's constructor. With this addition, the file can now run.

The color for the health and mana bar text used to be black but after changing the save files, I realized that, on darker backgrounds it's harder to see. I have changed the color to be white for now to fix this.

## PR checklist
 - [ ] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 