### PR TITLE
Pygame-RPG 17.2 Housekeeping and bugfixing

### DIFF
--- a/Entity/Enemy.py
+++ b/Entity/Enemy.py
@@ -10,11 +10,13 @@ class Enemy(Entity):
         self.uniqueBuff = jsonInfo["uniqueBuff"]  # For bosses only really
         self.weakness = jsonInfo["Weakness"]  # What stance they're weak to
 
-    def take_attack(self, damage, lootpool):  # take_attack is the Enemy specific version of `take_damage()`
+    def take_attack(self, damage, lootpool, effect=False):
+        # take_attack is the Enemy specific version of `take_damage()`
         # In this case it checks if the attack was fatal and then if it is, invokes the "`die()` function
-        self.take_damage(damage)
+        damageVal = self.take_damage(damage, effect)
         if self.Status == "Dead":
             self.die(lootpool)
+        return damageVal  # returns how much damage the unit took
 
     def die(self, lootPool):  # Will not work
         # add values to loot pool upon death

--- a/Entity/Entities_test.py
+++ b/Entity/Entities_test.py
@@ -12,9 +12,15 @@ lootpool = {"Exp": 0, "Money": 0, "Items": {}}
 
 def test_take_damage():
     mockEnemy.take_damage(-900)
+    mockEnemy.Defence = 100  # set defence to 100
+    mockEnemy.take_damage(20)  # should do no damage because of the high damage
     flag = mockEnemy.Hp == mockEnemy.Hpcap  # Hp shouldn't change
-    mockEnemy.take_damage(9999)
-    assert flag and mockEnemy.Hp == 0 and mockEnemy.Status == "Dead"
+    mockEnemy.take_damage(20, True)
+    flag2 = mockEnemy.Hp == mockEnemy.Hpcap - 20  # confirm that the mock enemy actually took damage
+    mockEnemy.take_damage(9999)  # kill the mock enemy
+    mockEnemy.Defence = 1  # reset the defence to 1
+
+    assert flag and flag2 and mockEnemy.Hp == 0 and mockEnemy.Status == "Dead"
 
 def test_apply_bonuses():
     mockEnemy.Bonuses.update({"Str": (50, 3), "Vit": (50, 3), "Agl": (50, -1), "Defence": (50, 3)})  # Give enemy buffs

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -4,32 +4,35 @@ class Entity:
     def __init__(self, Hp, Hpcap, Mp, Mpcap, name, level, strength, magic, vitality, agility, defence, exp, money, inventory=None):
         if inventory is None:
             inventory = {}  # Inventory is a dictionary of it with key pairs (string: int)
+        self.Name = name
+        self.Status = "Normal"
+        self.Lvl = level
         self.Hp = Hp
         self.Hpcap = Hpcap
         self.Mp = Mp
         self.Mpcap = Mpcap
-        self.Name = name
-        self.Lvl = level
+        self.Exp = exp
+        self.Bal = money
         self.Str = strength
         self.Mag = magic
         self.Vit = vitality
         self.Agl = agility
-        self.Status = "Normal"
+        self.Defence = defence
         self.Bonuses = {  # A dict of all positive and negative effects on Knight character, includes stance bonuses
             "Str": (0, -1), "Vit": (0, -1), "Agl": (0, -1), "Defence": (0, -1)  # -1 means unlimited duration for bonus
         }
-        self.Defence = defence
-        self.Exp = exp
-        self.Bal = money
         self.Inventory = inventory  # For heroes, it's a bunch of useful items, for monsters it's dropped items
 
-    def take_damage(self, damage):
-        damage = damage - self.Defence  # how much damage you ACTUALLY take
+    def take_damage(self, damage, effect=False):
+        if not effect:  # if it isn't effect damage, consider defence
+            damage = damage - self.Defence  # how much damage you ACTUALLY take
         if damage > 0 and self.Status != "Dead":  # Only allows positive damage to be inflicted on alive opponents
             self.Hp -= damage
             if self.Hp <= 0:  # Check if you died to the attack
                 self.Hp = 0  # Set hp to 0 or else weird things will start happening
                 self.Status = "Dead"  # Change status to dead
+            return damage
+        return 0  # if the damage is below 0
 
     def apply_bonuses(self, flag=True):
         # flag being False stops the turn count from lowering
@@ -69,3 +72,15 @@ class Entity:
 
     def __lt__(self, other):
         return other.Agl > self.Agl
+
+    ########## DEBUG FUNCTIONS (NO TESTING REQUIRED)
+
+    def print_status(self):
+        statusStr = ""
+        d = self.__dict__.copy()
+        for key, value in d.items():
+            if key == "Mp" or key == "Hp" or (key == "Exp" and d.get("Expcap") is not None):
+                statusStr += key + ":" + str(value) + "/" + str(d[key + "cap"]) + "\n"
+            elif key != "Hpcap" and key != "Mpcap" and key != "Expcap":
+                statusStr += key + ":" + str(value) + "\n"
+        print(statusStr)


### PR DESCRIPTION
### Pygame-RPG 17.2 Housekeeping and bugfixing
This PR adds some debugging functionality to the battle system by having the Entity objects print out their statuses to the console via the `print_status()` function that. This is then used by the BattleManager class in the debug function `print_all_statuses()`. This function prints the status of all active Entities at the end of their turn. This allows me to have a comprehensive view of what happened during that turn.

A quality of life change was also made to the `take_damage()` and `take_attack()` functions. Both functions now take in a default value of `False` at the end, this value relates to whether the damage that will be taken is from an effect. If the damage is not from an effect, the damage will be lowered by the object's defence stat. If the damage is from an effect, this does not happen, making effect essentially true damage.

This PR also fixes a bug that was in the battle system. Due to how the effect handling was done, the player could never kill enemy units with the effects. The reason for this is because the changes only affected the given stat and wouldn't change the status. This way, it was possible for an enemy object to be below 0 Hp and not get filtered at the end of the turn.

This is done by ensuring that if the affected stat of an event is Hp, instead of directly applying the change, `take_damage()` or `take_attack()` (Depending on the object's class), is instead called. The boolean flag `True` is also given to the function so that the damage isn't lowered by the defence stat (effect damage counts as true damage).

This PR also addresses an oversight that I made when creating the string array that the battle system gives at the end of every turn. The problem is that the damage reported is incorrect because it doesn't take into account the defence of the opponent. Essentially, it'll say the enemy took 100 damage when in reality their defence reduced it to 30. To fix this, we have the `take_damage()` and `take_attack()` functions return an integer that is the actual amount of damage the enemy took. We then use these for the reporting strings instead. A similar change was done to the effect version of this situation but it was mostly just to improve the structure of the code and reduce redundancy.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 