### PR TITLE
Pygame-RPG 18 Implementing Status System

### DIFF
--- a/Entity/Enemy.py
+++ b/Entity/Enemy.py
@@ -14,7 +14,7 @@ class Enemy(Entity):
         # take_attack is the Enemy specific version of `take_damage()`
         # In this case it checks if the attack was fatal and then if it is, invokes the "`die()` function
         damageVal = self.take_damage(damage, effect)
-        if self.Status == "Dead":
+        if self.Status[0] == "Dead":
             self.die(lootpool)
         return damageVal  # returns how much damage the unit took
 

--- a/Entity/Entities_test.py
+++ b/Entity/Entities_test.py
@@ -20,7 +20,7 @@ def test_take_damage():
     mockEnemy.take_damage(9999)  # kill the mock enemy
     mockEnemy.Defence = 1  # reset the defence to 1
 
-    assert flag and flag2 and mockEnemy.Hp == 0 and mockEnemy.Status == "Dead"
+    assert flag and flag2 and mockEnemy.Hp == 0 and mockEnemy.Status[0] == "Dead"
 
 def test_apply_bonuses():
     mockEnemy.Bonuses.update({"Str": (50, 3), "Vit": (50, 3), "Agl": (50, -1), "Defence": (50, 3)})  # Give enemy buffs

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -5,7 +5,7 @@ class Entity:
         if inventory is None:
             inventory = {}  # Inventory is a dictionary of it with key pairs (string: int)
         self.Name = name
-        self.Status = "Normal"
+        self.Status = ("Normal", -1)
         self.Lvl = level
         self.Hp = Hp
         self.Hpcap = Hpcap
@@ -26,11 +26,11 @@ class Entity:
     def take_damage(self, damage, effect=False):
         if not effect:  # if it isn't effect damage, consider defence
             damage = damage - self.Defence  # how much damage you ACTUALLY take
-        if damage > 0 and self.Status != "Dead":  # Only allows positive damage to be inflicted on alive opponents
+        if damage > 0 and self.Status[0] != "Dead":  # Only allows positive damage to be inflicted on alive opponents
             self.Hp -= damage
             if self.Hp <= 0:  # Check if you died to the attack
                 self.Hp = 0  # Set hp to 0 or else weird things will start happening
-                self.Status = "Dead"  # Change status to dead
+                self.Status = ("Dead", -1)  # Change status to dead
             return damage
         return 0  # if the damage is below 0
 

--- a/Entity/Knight.py
+++ b/Entity/Knight.py
@@ -5,6 +5,7 @@ class Knight(Entity):
     # The current stats still need to be changed to the default stats later
     def __init__(self, Hp=1, Hpcap=1, Mp=1, Mpcap=1, name="Rion", level=1, strength=1, magic=1, vitality=1, agility=1, defence=1, exp=0, expcap=1, money=0):
         Entity.__init__(self, Hp, Hpcap, Mp, Mpcap, name, level, strength, magic, vitality, agility, defence, exp, money)
+        self.fieldStatus = "Normal"
         self.Expcap = expcap
         self.Stance = "1"
         self.growths = {"Hpcap": self.Vit * 1 + 50, "Mpcap": self.Mpcap * 1 + 50, "Str": self.Str * 1 + 50, "Vit": self.Vit * 1 + 50,

--- a/JSON/Moves/Complete_Move_List.json
+++ b/JSON/Moves/Complete_Move_List.json
@@ -82,5 +82,17 @@
       "Probability": null,
       "Weight": 100,
       "Description": ""
+   },
+   "Venom Strike": {
+      "Damage Calculation": "Str * 1.0",
+      "Type": "Attack",
+      "Cost": 0,
+      "Restriction": null,
+      "Effect": "Apply Poison, T",
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": 100,
+      "Weight": 100,
+      "Description": "A strike that fills it's enemy with a lethal poison"
    }
 }

--- a/JSON/Status/Status.json
+++ b/JSON/Status/Status.json
@@ -1,0 +1,37 @@
+{
+   "Normal": {
+      "maxCount": -1,
+      "Effect": "",
+      "Description": "You're perfectly healthy"
+   },
+   "Dead": {
+      "maxCount": -1,
+      "Effect": "",
+      "Description": "You're dead"
+   },
+   "Bleed": {
+      "maxCount": 3,
+      "Effect": "-10% Hp",
+      "Description": "Lose 10% of your Hp per turn and reduces healing by 50%, cures after 3 turns"
+   },
+   "Paralyze": {
+      "maxCount": 1,
+      "Effect": "Lose turn",
+      "Description": "Lose your turn"
+   },
+   "Burn": {
+      "maxCount": 3,
+      "Effect": "-15% Hp",
+      "Description": "Lose 15% of your Hp per turn, cures after 3 turns"
+   },
+   "Poison": {
+      "maxCount": 5,
+      "Effect": "-10% Hpcap",
+      "Description": "Lose 10% of your max Hp per turn, cures after 5 turns"
+   },
+   "Freeze": {
+      "maxCount": 1,
+      "Effect": "-5% Hpcap, Lose turn",
+      "Description": "Lose your turn and lose 5% of your max Hp"
+   }
+}

--- a/Rpg2.py
+++ b/Rpg2.py
@@ -11,7 +11,7 @@ def display_frame_rate(font, screen):
 def handle_basic_input(keys, knightAni, knight, x, animationTracker): # This is just movement for left and right
     # Determines players overworld movement
     prevKnightAni = knightAni.aniArray
-    if knight.Status == "Normal":
+    if knight.fieldStatus == "Normal":
         if keys[game.K_RIGHT]:
             knightAni.change_array("Knight Run R")
             if prevKnightAni != knightAni.aniArray:
@@ -43,20 +43,20 @@ def handle_basic_input(keys, knightAni, knight, x, animationTracker): # This is 
 def handle_player_interaction(keys, knight, saveManager, screenManager, NPCManager, textEnable, animationTracker3):
     if keys[game.K_UP]:
         for u in range(len(interactables)):
-            status = knight.Status
+            status = knight.fieldStatus
             interactable = interactables[u]
             if interactable.eventType == "Chest":
                 screenManager.objectAni.change_tuple(knight, x, interactable)
-                if status != knight.Status:
+                if status != knight.fieldStatus:
                     # resetting animationTracker
                     animationTracker3 = 0
             elif interactable.eventType == "Dialogue":
                 textEnable = True
-                knight.Status = "In cutscene"
+                knight.fieldStatus = "In cutscene"
                 # Do something
 
             screenManager.objectAni.change_tuple(knight, x, interactable)
-            if status != knight.Status:
+            if status != knight.fieldStatus:
                 # resetting animationTracker
                 animationTracker3 = 0
 
@@ -161,7 +161,7 @@ while True:
     spot = animationTracker // 10
     spot2 = animationTracker2 // 10
     spot3 = animationTracker3 // 10
-    if knight.Status == "Dead":
+    if knight.fieldStatus == "Dead":
         knightAni.change_array("Death")
 
     eventList = game.event.get()
@@ -205,9 +205,9 @@ while True:
             animationTracker2 += 1
             # Animation tracker3 is for objects like chests and arrows
             if len(screenManager.objectAni.aniTuple) != 0 and animationTracker3 == (10 * screenManager.objectAni.aniTuple[0] - 1):
-                knight.Status = "Normal"
+                knight.fieldStatus = "Normal"
 
-            elif knight.Status != "Normal" and knight.Status != "Dead":
+            elif knight.fieldStatus != "Normal" and knight.fieldStatus != "Dead":
                 # Fine for now but this needs to be fixed
                 animationTracker3 += 1
 
@@ -279,7 +279,7 @@ while True:
                     }
 
                 }
-                knight.Status = "Normal"  # reset Knight's status to normal
+                knight.fieldStatus = "Normal"  # reset Knight's status to normal
             elif battleResult == "Hero Loses":
                 # send them back to the start menu and reset their player character?
                 pass

--- a/Scripts.py
+++ b/Scripts.py
@@ -223,4 +223,22 @@ if __name__ == "__main__":
         json.dump(effectJson, file, indent=3)
         file.close()
 
+    elif arg == "format-status-effects":
+        path = "JSON/Status.json"
+        file = open(path, "r")
+        statusJSON = json.load(file)
+        file.close()
+        newStatusJSON = {}
+        for key, value in statusJSON.items():
+            newStatusJSON.update({
+                key: {
+                    "maxCount": 0,
+                    "Effect": "",
+                    "Description": value
+                }
+            })
+        file = open(path, "w")
+        json.dump(newStatusJSON, file, indent=3)
+        file.close()
+
 

--- a/managers/Item_Manager_test.py
+++ b/managers/Item_Manager_test.py
@@ -123,7 +123,7 @@ def test_item_compatibility():
     bleedHealEffect = itemManager.get_effect("Bandages")  # get the effect to heal Bleed
     multiEffect = itemManager.get_effect("Elixir")  # get an item that has multiple effects
     # setting up knight object stats
-    knight.Status = "Burn"
+    knight.Status = ("Burn", 0)
     knight.Hpcap = 999
     knight.Hp = 20
     knight.Mpcap = 999
@@ -138,14 +138,14 @@ def test_item_compatibility():
     battleManager.apply_effects(healingEffectString, knight, None)
     flag = knight.Hp == 120  # knight should have healed 100 Hp from potion effect
     battleManager.apply_effects(bleedHealEffectString, knight, None)
-    flag2 = knight.Status == "Burn"  # using bandages on a burn shouldn't cure it
+    flag2 = knight.Status[0] == "Burn"  # using bandages on a burn shouldn't cure it
     battleManager.apply_effects(burnHealEffectString, knight, None)
-    flag3 = knight.Status == "Normal"  # burn should have been healed by the effect
+    flag3 = knight.Status[0] == "Normal"  # burn should have been healed by the effect
     battleManager.apply_effects(percentageHealingEffectString, knight, None)
     flag4 = 120 + int(.5 * knight.Hpcap) == knight.Hp  # the knight should have been healed by 50% of their max Hp
-    knight.Status = "Bleed"  # make the knight object have the Bleed status
+    knight.Status = ("Bleed", 0)  # make the knight object have the Bleed status
     battleManager.apply_effects(multiEffectString, knight, None)
-    flag5 = knight.Hp == (knight.Hpcap + 120 + int(.5 * knight.Hpcap)) and knight.Status == "Normal" and \
+    flag5 = knight.Hp == (knight.Hpcap + 120 + int(.5 * knight.Hpcap)) and knight.Status[0] == "Normal" and \
             knight.Mp - 1 == knight.Mpcap
     assert flag and flag2 and flag3 and flag4 and flag5
 

--- a/managers/Object_Animation_Manager.py
+++ b/managers/Object_Animation_Manager.py
@@ -18,5 +18,5 @@ class ObjectAnimationManager:
         within_range = pos > interactable.range[0] and pos < interactable.range[1]
         if within_range and not interactable.activated:
             self.aniTuple = object_ani_dict.get(interactable.eventType)
-            knight.Status = "Opening Chest"
+            knight.fieldStatus = "Opening Chest"
             interactable.activated = True

--- a/managers/Object_Animation_Manager_test.py
+++ b/managers/Object_Animation_Manager_test.py
@@ -22,7 +22,7 @@ def test_change_tuple():
         # Clearing the tuple
         objectAnimationManager.aniTuple = ()
         objectAnimationManager.change_tuple(knight, pos, interactable)
-        assert tuple(objectAnimationManager.aniTuple) == chestAniL and knight.Status == "Opening Chest"
+        assert tuple(objectAnimationManager.aniTuple) == chestAniL and knight.fieldStatus == "Opening Chest"
 
 
 

--- a/managers/Save_Manager.py
+++ b/managers/Save_Manager.py
@@ -81,6 +81,7 @@ class SaveManager:
         self.hero.load_dict(fileInfo["Knight"])  # Loading knight
         for stat, bonus in self.hero.Bonuses.items():  # turn all the list bonuses to tuples
             self.hero.Bonuses.update({stat: tuple(bonus)})
+        self.hero.Status = tuple(self.hero.Status)  # turn the list for status into a tuple
         self.screenManager.objectDict = fileInfo["screenManager"]["objectDict"]
         self.screenManager.change_context(fileInfo["screenManager"]["context"])
         interactablesInfo = fileInfo["screenManager"]["interactablesDict"]

--- a/save/save_data1.json
+++ b/save/save_data1.json
@@ -1,16 +1,22 @@
 {
    "Knight": {
-      "Hp": 52174,
-      "Hpcap": 52174,
-      "Mp": 52174,
-      "Mpcap": 52174,
       "Name": "Rion",
+      "Status": [
+         "Normal",
+         -1
+      ],
       "Lvl": 1,
-      "Str": 52174,
+      "Hp": 104398,
+      "Hpcap": 104398,
+      "Mp": 104398,
+      "Mpcap": 104398,
+      "Exp": 0,
+      "Bal": 0,
+      "Str": 104398,
       "Mag": 1,
-      "Vit": 52174,
-      "Agl": 52174,
-      "Status": "Normal",
+      "Vit": 104398,
+      "Agl": 104398,
+      "Defence": 104398,
       "Bonuses": {
          "Str": [
             0,
@@ -29,19 +35,17 @@
             -1
          ]
       },
-      "Defence": 52174,
-      "Exp": 0,
-      "Bal": 0,
       "Inventory": {},
+      "fieldStatus": "Normal",
       "Expcap": 1,
       "Stance": "1",
       "growths": {
-         "Hpcap": 52224,
-         "Mpcap": 52224,
-         "Str": 52224,
-         "Vit": 52224,
-         "Agl": 52224,
-         "Defence": 52224
+         "Hpcap": 104448,
+         "Mpcap": 104448,
+         "Str": 104448,
+         "Vit": 104448,
+         "Agl": 104448,
+         "Defence": 104448
       },
       "moveList": [
          "Attack"
@@ -55,11 +59,11 @@
       }
    },
    "rawVariables": {
-      "animationTracker": 8,
-      "animationTracker2": 22,
-      "animationTracker3": 4,
-      "gameState": 3,
-      "x": 93
+      "animationTracker": 19,
+      "animationTracker2": 88,
+      "animationTracker3": 23,
+      "gameState": 1,
+      "x": 719
    },
    "screenManager": {
       "context": "Background1",

--- a/save/save_data4.json
+++ b/save/save_data4.json
@@ -1,16 +1,22 @@
 {
    "Knight": {
-      "Hp": 52174,
-      "Hpcap": 52174,
-      "Mp": 52174,
-      "Mpcap": 52174,
       "Name": "Rion",
+      "Status": [
+         "Normal",
+         -1
+      ],
       "Lvl": 1,
-      "Str": 52174,
+      "Hp": 104398,
+      "Hpcap": 104398,
+      "Mp": 104398,
+      "Mpcap": 104398,
+      "Exp": 0,
+      "Bal": 0,
+      "Str": 104398,
       "Mag": 1,
-      "Vit": 52174,
-      "Agl": 52174,
-      "Status": "Normal",
+      "Vit": 104398,
+      "Agl": 104398,
+      "Defence": 104398,
       "Bonuses": {
          "Str": [
             0,
@@ -29,19 +35,17 @@
             -1
          ]
       },
-      "Defence": 52174,
-      "Exp": 0,
-      "Bal": 0,
       "Inventory": {},
+      "fieldStatus": "Normal",
       "Expcap": 1,
       "Stance": "1",
       "growths": {
-         "Hpcap": 52224,
-         "Mpcap": 52224,
-         "Str": 52224,
-         "Vit": 52224,
-         "Agl": 52224,
-         "Defence": 52224
+         "Hpcap": 104448,
+         "Mpcap": 104448,
+         "Str": 104448,
+         "Vit": 104448,
+         "Agl": 104448,
+         "Defence": 104448
       },
       "moveList": [
          "Attack"
@@ -55,11 +59,11 @@
       }
    },
    "rawVariables": {
-      "animationTracker": 8,
-      "animationTracker2": 22,
-      "animationTracker3": 4,
-      "gameState": 3,
-      "x": 93
+      "animationTracker": 19,
+      "animationTracker2": 88,
+      "animationTracker3": 23,
+      "gameState": 1,
+      "x": 719
    },
    "screenManager": {
       "context": "Background1",


### PR DESCRIPTION
### Pygame-RPG 18 Implementing Status System
This PR focuses on implementing a status system to the combat system. The first and largest change is that instead of using a string to represent the status of entities in combat, the status is represented as a tuple of size 2. Index 0 has the name of the status while index 1 has the turn count. a turn count of -1 means that it is an infinite status.

Information about statuses and their effects is stored in the `Status.json` file. The most important part of this information is the maxCount value for a given status. If a maxCount is not -1 (represents infinite statuses), the value represents the number of turns the status can be on an Entity before it is removed.

Because of the above changes, the hero object now has a new field called `fieldStatus` which does what the old `Status` variable used to do on the overworld in the `Rpg2.py` file. This way, I don't need to refactor much code and I can further separate the overworld and battle portions of the code. The final general change that was making functions that required the status string to look for the status string look at index 0 of the Status tuple.

Because of these changes and the implementation being for the battles, `BattleManager` received a variety of changes. The class gained a new attribute `statusDict` and 3 new functions, `get_status_dict()`, `apply_status_effects()` and `handle_status()`. The `do_one_turn()` function was also modified to take advantage of these changes. `apply_effects()` also received a minor change, now being able to apply effects to entity objects.

`get_status_dict()`: This function just parses and returns the dictionary contained in the `Status.json` file.

`apply_status_effects()`: This function takes in an entity object and returns a list of event strings. This function works similarly to the `apply_effects()` function and reuses much of the code. The main differences are the way it handles the effect strings and the effectStrings it creates which are added to a list which is returned by the function. The main change between how effect strings are handled is that `apply_effects()` assumes that the effect string -15% Hp means that you inflict 15% of the max Hp stat to the target.
`apply_status_effects()` will interpret the same string to mean inflict -15% of CURRENT Hp as damage. `apply_status_effects()` can handle effects based off of current and the cap stats but `apply_effects()` cannot. The two also do not handle the same types of effects. For example, `apply_effects()` can handle an effect string that tells it to apply a certain status effect to a target but `apply_status_effects()` cannot. The final difference is that `apply_status_effects()` will increase the "counter" for a status effect before it applies them.

`handle_status()`: This function takes in an Entity object and returns a list of event strings and calls on the `apply_status_effects()` function. Once the `apply_status_effects()` function is done, the function checks if the "counter" for the status has reached it's maximum value and if it has, it removes it, setting the status of the entity to Normal and adding another event string to the list that was received from `apply_status_effects()`.

`do_one_turn()`: received some changes in order to implement these changes. The main change being that before looking at which type of object is being called with this function, it checks if the object can even make a move by looking at it's status. If the status is one that has the effect of making them lose their turn, it just effectively skips their turn. `handle_status()` is still called however in order to handle any other effects caused by the status even if their turn is effectively skipped. This has the consequence of having the same repetitive bit of code appear in all 3 situations (turn is skipped, player character's turn and enemy's turn). This is an acceptable consequence as it is better than having the player enter a target and a move only to lose their turn. As a result of `handle_status()` returning it's own list of event strings, all instances of `returnable_strings` now add the returned lists instead of being set to them.

`apply_effects()`: The function now is able to apply effects and also now has new event strings for when the player uses an item to cure a status effect, one where it succeeds and one where it fails.

As with all other changes, the tests for these changes have been written. Because of these changes, the save files were updated as well.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 