### PR TITLE
Pygame-RPG 18.1 Housekeeping and bugfixing

### DIFF
--- a/Entity/Battle_Manager.py
+++ b/Entity/Battle_Manager.py
@@ -104,7 +104,7 @@ class BattleManager:
                 self.turnOrder.pop(0)  # remove the enemy entity from turnOrder
                 #self.print_all_statuses()  ######## DEBUG
         # clear dead enemies should return a string of people who died to returnable strings
-        self.clear_dead_enemies()  # removes dead entities
+        returnable_strings += self.clear_dead_enemies()  # removes dead entities and add event strings
         self.fix_entity_stats()  # correct the stats of all entities that are still alive
         return returnable_strings, refresh
 
@@ -274,16 +274,17 @@ class BattleManager:
 
     def reset_turn_order(self):
         if len(self.turnOrder) == 0:
-            # add the hero object to the turn order with the agility stat as the first index of the tuple
+            # add the hero object
             self.turnOrder.append(self.hero)
-            # add the enemy objects to the turn order with the agility stat as the first index of the tuple
+            # add the enemy objects
             for i in range(len(self.enemies)):
                 enemy = self.enemies[i][1]
                 self.turnOrder.append(enemy)
             # sort the list, since the tuple has a number in the first index in descending order
-            self.turnOrder.sort(reverse=True)  # WILL BREAK IF MULTIPLE OF THE SAME ENEMY EXISTS IN LIST
+            self.turnOrder.sort(reverse=True)
 
     def clear_dead_enemies(self):
+        returnableStrings = []
         newEnemies = []  # empty list of enemies that aren't dead
         newTurnOrder = []  # empty list of entities that aren't dead
         # Loop through enemies list and append the not dead enemies to the newEnemies list
@@ -291,6 +292,8 @@ class BattleManager:
             enemy = self.enemies[i][1]
             if enemy.Status[0] != "Dead":
                 newEnemies.append(self.enemies[i])
+            else:
+                returnableStrings.append(enemy.Name + " died!")
         self.enemies = newEnemies  # set the enemies list to the newEnemies list
         # Loop through the turnOrder list and append the not dead entities to the newTurnOrder list
         # turnOrder does not need position of the enemy Object
@@ -299,6 +302,7 @@ class BattleManager:
             if enemy.Status[0] != "Dead":
                 newTurnOrder.append(enemy)
         self.turnOrder = newTurnOrder  # set the turnOrder list to the newTurnOrder list
+        return returnableStrings
 
     def fix_entity_stats(self):
         # Goes through all Entities and fixes their stats

--- a/Entity/Battle_Manager_test.py
+++ b/Entity/Battle_Manager_test.py
@@ -128,9 +128,10 @@ def test_reset_turn_order():
 
 def test_clear_dead_enemies():
     battleManager.enemies[0][1].Status = ("Dead", -1)  # Change Dummy status to Dead
-    battleManager.clear_dead_enemies()  # clear the dead enemies
-    # Check if the enemies list is empty and only the hero object should be in turn order now
-    assert len(battleManager.enemies) == 0 and len(battleManager.turnOrder) == 1
+    returnableStrings = battleManager.clear_dead_enemies()  # clear the dead enemies
+    # Check if the enemies list is empty and only the hero object should be in turn order
+    # also checks to see if the event string was added
+    assert len(battleManager.enemies) == 0 and len(battleManager.turnOrder) == 1 and len(returnableStrings) == 1
 
 def test_fix_entity_stats():
     knight.Hp = 999

--- a/Scripts.py
+++ b/Scripts.py
@@ -223,22 +223,23 @@ if __name__ == "__main__":
         json.dump(effectJson, file, indent=3)
         file.close()
 
-    elif arg == "format-status-effects":
-        path = "JSON/Status.json"
+    elif arg == "add-status":
+        arg2 = sys.argv[2]  # There will a second argument with this
+        path = "JSON/Status/Status.json"
         file = open(path, "r")
         statusJSON = json.load(file)
         file.close()
-        newStatusJSON = {}
-        for key, value in statusJSON.items():
-            newStatusJSON.update({
-                key: {
+        statusJSON.update({
+                arg2: {
                     "maxCount": 0,
                     "Effect": "",
-                    "Description": value
+                    "Description": ""
                 }
             })
         file = open(path, "w")
-        json.dump(newStatusJSON, file, indent=3)
+        json.dump(statusJSON, file, indent=3)
         file.close()
+
+
 
 

--- a/script
+++ b/script
@@ -53,6 +53,11 @@ case $args in
 
   update-saves)
     python scripts.py update-saves
+  ;;
+
+  add-status)
+    python scripts.py add-status "$args2"
+
 
 
 esac


### PR DESCRIPTION
### Pygame-RPG 18.1 Housekeeping and bugfixing
This PR erases some unnecessary comments and adds new event strings to the `do_one_turn()` functions by adjusting the `clear_dead_enemies()` function. This function now adds event strings to a list when enemies die. This PR also refactors the tests to accommodate the changes and updates the scripts to add a script that adds a status effect to the Status.json file.

## PR checklist
 - [ ] All Pytests pass
 - [ ] All changes are documented somewhere in the commit
 - [ ] Rpg2.py is tested and works even with the changes
 