### PR TITLE
Pygame-RPG 19.2 Upgrading Battle System

### DIFF
--- a/Entity/Battle_Manager.py
+++ b/Entity/Battle_Manager.py
@@ -142,22 +142,28 @@ class BattleManager:
     def parse_effects(self, effectString):
         effectList = []
         if effectString is not None:
-            effects = effectString.split(",")
-            if len(effects) % 2 == 0:
-                # immediate effect
-                for i in range(0, len(effects), 2):
-                    effect = effects[i]
-                    target = effects[i + 1].strip()
+            splitEffects = effectString.split("|")
+            for i in range(len(splitEffects)):
+                effects = splitEffects[i].split(",")
+                lastVal = effects[-1]  # get the last value in the last
+                lastVal = lastVal.strip()  # strip white space
+                if lastVal != "S" and lastVal != "T":
+                    # implied self effect
+                    effects.append("S")
+                if len(effects) == 2:
+                    # immediate effect
+                    effect = effects[0]
+                    target = effects[1].strip()
                     effectList.append((target, effect))
 
-            elif len(effects) % 3 == 0:
-                # Debuff/buff effect
-                for i in range(0, len(effects), 3):
-                    buffAndStat = effects[i].split()
-                    buff = int(buffAndStat[i])
-                    stat = buffAndStat[i + 1]
-                    target = effects[i + 1].strip()
-                    buff = {stat: (buff, int(effects[i + 2]))}
+                elif len(effects) == 3:
+                    # Debuff/buff effect
+                    buffAndStat = effects[0].split()
+                    buff = int(buffAndStat[0])
+                    stat = buffAndStat[1]
+                    target = effects[2].strip()
+                    buffDuration = effects[1]
+                    buff = {stat: (buff, int(buffDuration))}
                     effectList.append((target, buff))  # tuple with target and the buff
         return effectList
 

--- a/Entity/Battle_Manager_test.py
+++ b/Entity/Battle_Manager_test.py
@@ -22,6 +22,7 @@ statusMove = Move("Venom Strike", dummy, battleManager.moveDict["Venom Strike"])
 buffEffectMove = Move("Angry Shout", dummy, battleManager.moveDict["Angry Shout"])
 immediateMove = Move("Pilfering Strike", dummy, battleManager.moveDict["Pilfering Strike"])
 healMove = Move("Drink Potion", dummy, battleManager.moveDict["Drink Potion"])
+hybridMove = Move("Defensive Stance", dummy, battleManager.moveDict["Defensive Stance"])
 # AOE moves can only be play tested because they utilise the logic in the do_one_turn function which is play tested
 
 
@@ -52,6 +53,7 @@ def test_parse_effects():
     flag3 = effectListMatrix[2][0][0] == "T" and isinstance(effectListMatrix[2][0][1], str)
     effectListMatrix.append(battleManager.parse_effects(healMove.effect))  # add the heal move effect list for later test
     effectListMatrix.append(battleManager.parse_effects(statusMove.effect))  # add status move for later test
+    effectListMatrix.append(battleManager.parse_effects(hybridMove.effect))  # add the hybrid move for later test
     # Check the flags
     assert flag and flag2 and flag3
 
@@ -78,7 +80,8 @@ def test_apply_effects():
         # run apply_effects() and add to the list of event strings
         eventStrings = eventStrings + battleManager.apply_effects(effectList, dummy, knight)
     # Check if all the effects were properly applied
-    flag = dummy.Bonuses["Str"] == (5, 3) and knight.Bal == 0 and oldDummyHp + 20 == dummy.Hp and len(eventStrings) == 4
+    flag = dummy.Bonuses["Str"] == (5, 3) and knight.Bal == 0 and oldDummyHp + 40 == dummy.Hp and len(eventStrings) == 6 \
+           and dummy.Bonuses["Defence"] == (10, 3)
     # check to see if the poison was applied
     flag2 = knight.Status[0] == "Poison" and knight.Status[1] == 0
     assert flag and flag2

--- a/JSON/Items/Item_Effects.json
+++ b/JSON/Items/Item_Effects.json
@@ -2,57 +2,57 @@
    "Old Bread": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+20 Hp, S"
+      "Effect": "+20 Hp"
    },
    "Potion": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+100 Hp, S"
+      "Effect": "+100 Hp"
    },
    "Ether": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+50 Mp, S"
+      "Effect": "+50 Mp"
    },
    "Hi-Ether": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+100 Mp, S"
+      "Effect": "+100 Mp"
    },
    "Hi-Potion": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+200 Hp, S"
+      "Effect": "+200 Hp"
    },
    "Dragon Tear": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+50% Hp, S"
+      "Effect": "+50% Hp"
    },
    "Medicinal Herbs": {
       "Target": "S",
       "AOE": false,
-      "Effect": "Cure Poison, S"
+      "Effect": "Cure Poison"
    },
    "Bandages": {
       "Target": "S",
       "AOE": false,
-      "Effect": "Cure Bleed, S"
+      "Effect": "Cure Bleed"
    },
    "Elixir": {
       "Target": "S",
       "AOE": false,
-      "Effect": "+100% Hp, S, +100% Mp, S, Cure All, S"
+      "Effect": "+100% Hp | +100% Mp | Cure All"
    },
    "Ointment": {
       "Target": "S",
       "AOE": false,
-      "Effect": "Cure Burn, S"
+      "Effect": "Cure Burn"
    },
    "Paralyze Tonic": {
       "Target": "S",
       "AOE": false,
-      "Effect": "Cure Paralyze, S"
+      "Effect": "Cure Paralyze"
    },
    "Bomb": {
       "Target": "T",

--- a/JSON/Moves/Complete_Move_List.json
+++ b/JSON/Moves/Complete_Move_List.json
@@ -40,7 +40,7 @@
       "Type": "Buff",
       "Cost": 60,
       "Restriction": null,
-      "Effect": "+5 Str, S, 3",
+      "Effect": "+5 Str, 3",
       "AOE": false,
       "Target Number": 1,
       "Probability": null,
@@ -52,7 +52,7 @@
       "Type": "Heal",
       "Cost": 40,
       "Restriction": null,
-      "Effect": "+20 Hp, S",
+      "Effect": "+20 Hp",
       "AOE": false,
       "Target Number": 1,
       "Probability": null,
@@ -94,5 +94,17 @@
       "Probability": 100,
       "Weight": 100,
       "Description": "A strike that fills it's enemy with a lethal poison"
+   },
+   "Defensive Stance": {
+      "Damage Calculation": "",
+      "Type": "",
+      "Cost": 0,
+      "Restriction": null,
+      "Effect": "+20 Hp | +10 Defence, 3",
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": null,
+      "Weight": 100,
+      "Description": "Adopt a defensive position and heal a minor amount of health"
    }
 }


### PR DESCRIPTION
### Pygame-RPG 19.2 Upgrading Battle System
This PR is meant to add new functionality to the parsing of effects. This PR modifies the `parse_effect()` function as well as the JSON strings for both item and move effects. This change allows for both immediate and buff/debuff effects to coexist in one effect string. This is done by dividing the effects with an indicator. The "|" character in an effect string indicates the beginning of a new effect.

By splitting the effect string using the "|" character, we are giving the individual effects in a string form that we can now process. Now, using this list, we check the length of the array we get by splitting the list by the "," character and processing them according to their length (length of 2 is immediate, 3 is buff/debuff).

This next change is designed to imply the target if none is given in the effect string. While the old format is easy to write, it came with the downside of always having to write the "S" character as the target when most of the effects are applied to the user by default

To circumvent this, a new condition is added before the code checks the length of the array. It now checks the final index of the array to see if there is a targeting indicator ("S" or "T"). If there isn't, the code appends "S" to the list making the "S" implied if there is no given target. To make this change the effect strings format for the Buff/debuff effect needed to be changed.

Old Format: Buff/Debuff, Target, Duration

New Format: Buff/Debuff, Duration, Target

The only change was that target and duration have swapped positions. With this new change, the item and move effects were changed to remove the targeting indicator if the effect only applied to the user and the effect strings now have the "|" character to divide up the different effects.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 