### PR TITLE
Pygame-RPG 19.3 Upgrade Battle System

### DIFF
--- a/JSON/Moves/Complete_Move_List.json
+++ b/JSON/Moves/Complete_Move_List.json
@@ -73,7 +73,7 @@
    },
    "Super Attack": {
       "Damage Calculation": "Str * 5",
-      "Type": "",
+      "Type": "Attack",
       "Cost": 0,
       "Restriction": "Hp > 100%",
       "Effect": null,
@@ -97,7 +97,7 @@
    },
    "Defensive Stance": {
       "Damage Calculation": "",
-      "Type": "",
+      "Type": "Buff",
       "Cost": 0,
       "Restriction": null,
       "Effect": "+20 Hp | +10 Defence, 3",
@@ -106,5 +106,17 @@
       "Probability": null,
       "Weight": 100,
       "Description": "Adopt a defensive position and heal a minor amount of health"
+   },
+   "Double Slash": {
+      "Damage Calculation": "Str * 0.4",
+      "Type": "Attack",
+      "Cost": 0,
+      "Restriction": null,
+      "Effect": null,
+      "AOE": false,
+      "Target Number": 2,
+      "Probability": null,
+      "Weight": 100,
+      "Description": "Slash enemies twice in quick succession"
    }
 }

--- a/Rpg2.py
+++ b/Rpg2.py
@@ -122,6 +122,7 @@ font = game.font.Font('font/Pixeltype.ttf', 50)
 
 # Hero Object
 knight = Entity.Knight()
+knight.moveList.append("Double Slash")
 
 # Think I'll go for the 1422 x 800 route from now on
 tempScreen = game.image.load("Background_Art/gothic_chapel_portfolio_1422x800.png")
@@ -154,7 +155,7 @@ UIHandler = managers.UIHandler(UIManager, saveManager, knight, vars(), battleMan
 interactables = screenManager.interactables
 textEnable = True  # For the purposes of this test
 buffered_move = ""  # for battlemanager
-target = ()  # for battlemanager
+target = []  # for battlemanager
 
 screenManager.change_context("Start")
 while True:
@@ -198,8 +199,7 @@ while True:
                 if len(dialogueManager.dialogue) == 0:
                     dialogueManager.load_file(mockDialogEvent)
                 textEnable = dialogueManager.draw_dialogue(eventList)
-                if not textEnable:
-                    print(dialogueManager.dialogue)
+
 
             # Animation tracker is for the knight(player character)
             animationTracker += 1
@@ -248,9 +248,9 @@ while True:
                 if len(dialogueManager.dialogue) == 0:
                     battleManager.determine_battle_state()  # checks to see if the battle state has changed
             else:
-                if buffered_move != "" and target != ():
+                if buffered_move != "" and len(target) == battleManager.targetNum:
                     buffered_move = ""
-                    target = ()
+                    target.clear()  # remove the targets from the list
                 if len(battleManager.turnOrder) == 0:
                     battleManager.reset_turn_order()
                 if battleManager.turnOrder[0] == knight:
@@ -261,9 +261,18 @@ while True:
                     # See if the move selected is a valid move
                     if battleManager.moveDict.get(choice) is not None or itemManager.itemJson.get(choice) is not None:
                         buffered_move = choice  # set the buffered move
+                        if battleManager.moveDict.get(choice) is not None:
+                            battleManager.set_target_number(choice)
+                        else:
+                            battleManager.targetNum = 1
                     elif isinstance(choice, tuple):
-                        target = choice
-                        UIManager.change_UI(None)
+                        if len(battleManager.enemies) > 1:  # we don't assume anything
+                            target.append(choice)  # add the choice to the tuple
+                        elif len(battleManager.enemies) == 1:  # if there is 1 enemy assume all hits target them
+                            for i in range(battleManager.targetNum):
+                                target.append(choice)
+                        if len(target) == battleManager.targetNum:  # check if we should leave targeting screen
+                            UIManager.change_UI(None)
                 returnable_strings, refresh = battleManager.do_one_turn(buffered_move, target)
                 if refresh:
                     UIManager.subMenuItems = itemManager.get_usable_items()  # refresh displayed


### PR DESCRIPTION
###  Pygame-RPG 19.3 Upgrade Battle System
This PR focuses on allowing multi target skills to be usable by the current battle system. In order to do this, changes to the BattleManager class and the Rpg2.py file need to be made.

Changes made in BattleManager class:
To track the number of selected targets a move needs, a new attribute called `targetNum` was created which starts at the value of -1 (meaning it's inactive). A new function called `set_target_number()` was made and the `do_one_move()` function was modified.

`targetNum`: This is an integer value that gets set to a positive number when a move is chosen. Once the move has been used, the value is to be reset to -1 signifying that it isn't in use.

`set_target_number()`: This function sets the `targetNum` value based off of the name of the chosen move given.

`do_one_turn()`: The major change made for this function is that the move of a Knight object is not proccessed unless the amount of targets matches with the `targetNum` attribute of the class. This way, the player doesn't use moves prematurely. The player can target the same enemy multiple times or choose a different one. This change also allows the enemy to use multi-hit attacks as well, the only difference is that since the player is the only person that the enemies can target, they'll simply always target them.

Changes made to the Rpg2.py file:
The target variable that is used for BattleManager is now a list rather than a tuple. This allows us to add and remove things as we please. There were also changes relating to the clear conditions of the `buffered_move` and `target` variables. Now, to clear these variables, `buffered_move` needs to have a valid value and the length of the `target` list needs to be equal to the targetNum attribute in the BattleManager object.

A change was also made when a move is chosen. If the move is a valid move, the BattleManager classes `targetNum` attribute is set using the `set_target_number()` function if it is a valid move. If the choice is an item, the attribute is set to 1 (for now we assume there are no multi-hit items. The UI also doesn't change if the player hasn't specified who to hit for every hit of the move.

Finally, there was a quality of life change for when the player selects a multi-hit move when there's only a single enemy left in the battle. The game will automatically hit the enemy with all of the hits, saving the player time.

## PR checklist
 - [ ] All Pytests pass
 - [ ] All changes are documented somewhere in the commit
 - [ ] Rpg2.py is tested and works even with the changes
 