### PR TITLE
Pygame-RPG 19.6 Housekeeping and bugfixing

### DIFF
--- a/JSON/Dictionaries/ScreenManager.json
+++ b/JSON/Dictionaries/ScreenManager.json
@@ -7,13 +7,13 @@
    "interactables_dict": {
       "Background1": [
          {
-            "range": [
+            "Range": [
                500,
                600
             ],
-            "eventType": "Chest",
-            "activated": false,
-            "path": ""
+            "EventType": "Chest",
+            "Activated": false,
+            "Path": ""
          }
       ],
       "Background2": []

--- a/Rpg2.py
+++ b/Rpg2.py
@@ -45,12 +45,12 @@ def handle_player_interaction(keys, knight, saveManager, screenManager, NPCManag
         for u in range(len(interactables)):
             status = knight.fieldStatus
             interactable = interactables[u]
-            if interactable.eventType == "Chest":
+            if interactable["EventType"] == "Chest":
                 screenManager.objectAni.change_tuple(knight, x, interactable)
                 if status != knight.fieldStatus:
                     # resetting animationTracker
                     animationTracker3 = 0
-            elif interactable.eventType == "Dialogue":
+            elif interactable["EventType"] == "Dialogue":
                 textEnable = True
                 knight.fieldStatus = "In cutscene"
                 # Do something
@@ -110,8 +110,8 @@ def change_screen(x, screenManager, NPCManager):
 interact_functions = {}
 
 # Make this hard coded for now
-mockJson = {"eventType": "Dialogue", "path": "event_text/Test_dialogue.txt"}
-mockDialogEvent = managers.Event(mockJson)
+mockJson = {"EventType": "Dialogue", "Path": "event_text/Test_dialogue.txt", "Activated": False}
+
 
 # I should have an array of sprite managers and it goes through them
 game.init()
@@ -197,7 +197,7 @@ while True:
             # Code for testing the dialogueManager
             if textEnable:
                 if len(dialogueManager.dialogue) == 0:
-                    dialogueManager.load_file(mockDialogEvent)
+                    dialogueManager.load_file(mockJson)
                 textEnable = dialogueManager.draw_dialogue(eventList)
 
 

--- a/managers/Dialogue_Manager.py
+++ b/managers/Dialogue_Manager.py
@@ -22,8 +22,8 @@ class DialogueManager:
 
     def load_file(self, event):
         # Loads the file that we read from
-        file = open(event.path)  # file that's being accessed
-        event.activated = True  # set the event to true
+        file = open(event["Path"])  # file that's being accessed
+        event["Activated"] = True  # set the event to true
         flag = True
         # adds all text in the file to a list
         while flag:

--- a/managers/Dialogue_Manager_test.py
+++ b/managers/Dialogue_Manager_test.py
@@ -1,7 +1,6 @@
 import pygame
 
 from managers.Dialogue_Manager import DialogueManager
-from managers.Screen_Manager import Event
 import pygame as game
 
 game.init()
@@ -10,12 +9,11 @@ clock = game.time.Clock()
 game.display.set_caption("Legend of Zeroes, Trails of Cold Meals")
 font = game.font.Font('font/Pixeltype.ttf', 50)
 dialogueManager = DialogueManager(font, screen)
-mockJson = {"eventType": "Dialogue", "path": "event_text/Test_dialogue.txt"}
-mockDialogEvent = Event(mockJson)
+mockJson = {"EventType": "Dialogue", "Path": "event_text/Test_dialogue.txt", "Activated": False}
 
 def get_size_of_file(event):
     i = 0
-    file = open(event.path, "r")
+    file = open(event["Path"], "r")
     text = file.readline()
     while text != "":
         text = file.readline()
@@ -26,9 +24,9 @@ def get_size_of_file(event):
 def test_load_file():
     # check to see if the file loaded and that there is no missing lines
     # also confirm that the event is activated
-    dialogueManager.load_file(mockDialogEvent)
-    assert len(dialogueManager.dialogue) == get_size_of_file(mockDialogEvent) and \
-        mockDialogEvent.activated
+    dialogueManager.load_file(mockJson)
+    assert len(dialogueManager.dialogue) == get_size_of_file(mockJson) and \
+        mockJson["Activated"]
 
 def test_get_new_text():
     dialogueCopy = dialogueManager.dialogue.copy()

--- a/managers/Object_Animation_Manager.py
+++ b/managers/Object_Animation_Manager.py
@@ -15,8 +15,8 @@ class ObjectAnimationManager:
             self.aniTuple = chestAniL
 
     def change_tuple(self, knight, pos, interactable):
-        within_range = pos > interactable.range[0] and pos < interactable.range[1]
-        if within_range and not interactable.activated:
-            self.aniTuple = object_ani_dict.get(interactable.eventType)
+        within_range = pos > interactable["Range"][0] and pos < interactable["Range"][1]
+        if within_range and not interactable["Activated"]:
+            self.aniTuple = object_ani_dict.get(interactable["EventType"])
             knight.fieldStatus = "Opening Chest"
-            interactable.activated = True
+            interactable["Activated"] = True

--- a/managers/Object_Animation_Manager_test.py
+++ b/managers/Object_Animation_Manager_test.py
@@ -1,5 +1,4 @@
 from managers.Object_Animation_Manager import ObjectAnimationManager
-from managers.Screen_Manager import Event
 from Entity.Knight import Knight
 
 objectAnimationManager = ObjectAnimationManager()
@@ -16,12 +15,11 @@ def test_set_Array():
 
 def test_change_tuple():
         knight = Knight()
-        mockJson = {"range": (500, 600), "eventType": "Chest"}
-        interactable = Event(mockJson)
+        mockJson = {"Range": (500, 600), "EventType": "Chest", "Activated": False}  # minimum viable Event JSON
         pos = 550
         # Clearing the tuple
         objectAnimationManager.aniTuple = ()
-        objectAnimationManager.change_tuple(knight, pos, interactable)
+        objectAnimationManager.change_tuple(knight, pos, mockJson)
         assert tuple(objectAnimationManager.aniTuple) == chestAniL and knight.fieldStatus == "Opening Chest"
 
 

--- a/managers/Save_Manager_test.py
+++ b/managers/Save_Manager_test.py
@@ -2,9 +2,8 @@ import os
 import pygame as game
 import random
 from Entity.Knight import Knight
-from managers.Save_Manager import SaveManager, tuplefy
+from managers.Save_Manager import SaveManager, tuplefy, tuplefy2
 from managers.Screen_Manager import ScreenManager
-from managers.Screen_Manager import Event
 
 def cleanup():
     os.system("bash script clear-save")
@@ -22,27 +21,12 @@ def fill_screenManager_dict():
     screenManager_dict.update({"objectDict": screenManager.objectDict})
 
 def fill_event_dict():
-    interactablesVars = {}
-    for key in screenManager.interactablesDict:
-        eventsVar = []
-        eventsTuple = screenManager.interactablesDict[key]
-        for i in range(len(eventsTuple)):
-            eventsVar.append(vars(eventsTuple[i]))
-        interactablesVars.update({key: tuple(eventsVar)})
-    eventDict.update(interactablesVars)
+    for key, value in screenManager.interactablesDict.items():
+        eventDict.update({key: value})
+
 
 def verify_interactables():
-    flag = True
-    mockJson = {"Range": (300, 400)}
-    event = Event(mockJson)  # Just for init. These values mean nothing
-    for key in screenManager.interactablesDict:
-        i = 0
-        dictVals = eventDict[key]
-        while i < len(dictVals) and flag:
-            event.load(dictVals[i])
-            flag = event == screenManager.interactablesDict[key][i]
-            i += 1
-    return flag
+    return tuplefy2(eventDict) == screenManager.interactablesDict
 # Replicating an actual game
 game.init()
 screen = game.display.set_mode((1422, 800))

--- a/managers/Screen_Manager.py
+++ b/managers/Screen_Manager.py
@@ -2,36 +2,13 @@ import pygame as game
 import json
 from managers.Object_Animation_Manager import ObjectAnimationManager
 
-class Event:
-
-    def __init__(self, eventInfo):
-        self.range = eventInfo.get("range")
-        self.eventType = eventInfo.get("eventType")  # Can't be None
-        self.activated = eventInfo.get("activated")  # Can't be None
-        self.path = eventInfo.get("path")
-
-    def load(self, infoDict):
-        self.range = tuple(infoDict["range"])
-        self.eventType = infoDict["eventType"]
-        self.activated = infoDict["activated"]
-        self.path = infoDict["path"]
-
-    def __eq__(self, other):
-        return self.__dict__ == other.__dict__
-
 def initiate_variables():
     # Function that pulls JSON information to create dictionaries
     file = open("JSON/Dictionaries/ScreenManager.json", "r")  # Opens the file
     screenManagerInfo = json.load(file)  # Load JSON information
     i_dict = screenManagerInfo["interactables_dict"]  # interactables_dict information
-    temp_dict = {}
-    for key in i_dict:  # Go through the array and turn the event dictionary information into Event objects
-        temp_array = []
-        for eventInfo in i_dict[key]:
-            temp_array.append(Event(eventInfo))
-        temp_dict.update({key: tuple(temp_array)})
     file.close()
-    return screenManagerInfo["background_dict"], temp_dict, screenManagerInfo["objects_dict"]  # Return the values
+    return screenManagerInfo["background_dict"], i_dict, screenManagerInfo["objects_dict"]  # Return the values
 
 screen_dict = {("Background1", 1): "Background2", ("Background2", -1): "Background1"}  # For now this can't be JSONED
 background_dict, interactables_dict, objects_dict = initiate_variables()

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -1,6 +1,6 @@
 from managers.NPC_Animation_Manager import NPCAnimationManager
 from managers.Object_Animation_Manager import ObjectAnimationManager
-from managers.Screen_Manager import ScreenManager, Event
+from managers.Screen_Manager import ScreenManager
 from managers.Dialogue_Manager import DialogueManager
 from managers.Save_Manager import SaveManager
 from managers.UI_Manager import UIManager

--- a/save/save_data1.json
+++ b/save/save_data1.json
@@ -6,17 +6,17 @@
          -1
       ],
       "Lvl": 1,
-      "Hp": 104398,
-      "Hpcap": 104398,
-      "Mp": 104398,
-      "Mpcap": 104398,
+      "Hpcap": 835534,
+      "Hp": 835534,
+      "Mpcap": 835534,
+      "Mp": 835534,
       "Exp": 0,
       "Bal": 0,
-      "Str": 104398,
+      "Str": 835534,
       "Mag": 1,
-      "Vit": 104398,
-      "Agl": 104398,
-      "Def": 104398,
+      "Vit": 835534,
+      "Agl": 835534,
+      "Def": 835534,
       "Bonuses": {
          "Str": [
             0,
@@ -40,12 +40,12 @@
       "Expcap": 1,
       "Stance": "1",
       "growths": {
-         "Hpcap": 104448,
-         "Mpcap": 104448,
-         "Str": 104448,
-         "Vit": 104448,
-         "Agl": 104448,
-         "Def": 104448
+         "Hpcap": 835584,
+         "Mpcap": 835584,
+         "Str": 835584,
+         "Vit": 835584,
+         "Agl": 835584,
+         "Def": 835584
       },
       "moveList": [
          "Attack"
@@ -59,11 +59,11 @@
       }
    },
    "rawVariables": {
-      "animationTracker": 19,
-      "animationTracker2": 88,
-      "animationTracker3": 23,
-      "gameState": 1,
-      "x": 719
+      "animationTracker": 35,
+      "animationTracker2": 74,
+      "animationTracker3": 11,
+      "gameState": 3,
+      "x": 83
    },
    "screenManager": {
       "context": "Background1",
@@ -80,13 +80,13 @@
       "interactablesDict": {
          "Background1": [
             {
-               "range": [
+               "Range": [
                   500,
                   600
                ],
-               "eventType": "Chest",
-               "activated": false,
-               "path": ""
+               "EventType": "Chest",
+               "Activated": false,
+               "Path": ""
             }
          ],
          "Background2": []

--- a/save/save_data4.json
+++ b/save/save_data4.json
@@ -6,17 +6,17 @@
          -1
       ],
       "Lvl": 1,
-      "Hp": 104398,
-      "Hpcap": 104398,
-      "Mp": 104398,
-      "Mpcap": 104398,
+      "Hpcap": 835534,
+      "Hp": 835534,
+      "Mpcap": 835534,
+      "Mp": 835534,
       "Exp": 0,
       "Bal": 0,
-      "Str": 104398,
+      "Str": 835534,
       "Mag": 1,
-      "Vit": 104398,
-      "Agl": 104398,
-      "Def": 104398,
+      "Vit": 835534,
+      "Agl": 835534,
+      "Def": 835534,
       "Bonuses": {
          "Str": [
             0,
@@ -40,12 +40,12 @@
       "Expcap": 1,
       "Stance": "1",
       "growths": {
-         "Hpcap": 104448,
-         "Mpcap": 104448,
-         "Str": 104448,
-         "Vit": 104448,
-         "Agl": 104448,
-         "Def": 104448
+         "Hpcap": 835584,
+         "Mpcap": 835584,
+         "Str": 835584,
+         "Vit": 835584,
+         "Agl": 835584,
+         "Def": 835584
       },
       "moveList": [
          "Attack"
@@ -59,11 +59,11 @@
       }
    },
    "rawVariables": {
-      "animationTracker": 19,
-      "animationTracker2": 88,
-      "animationTracker3": 23,
-      "gameState": 1,
-      "x": 719
+      "animationTracker": 35,
+      "animationTracker2": 74,
+      "animationTracker3": 11,
+      "gameState": 3,
+      "x": 83
    },
    "screenManager": {
       "context": "Background1",
@@ -80,13 +80,13 @@
       "interactablesDict": {
          "Background1": [
             {
-               "range": [
+               "Range": [
                   500,
                   600
                ],
-               "eventType": "Chest",
-               "activated": false,
-               "path": ""
+               "EventType": "Chest",
+               "Activated": false,
+               "Path": ""
             }
          ],
          "Background2": []


### PR DESCRIPTION
### Pygame-RPG 19.6 Housekeeping and bugfixing
Due to some, really dumb past decisions, I made the Event class to basically act as a struct of sorts. The issue is, that's completely unnecessary since the dictionary is already structured and the class has no unique methods. As such, I'm retroactively deleting the Event class and replacing it with dictionaries instead. This way, I can save and load events easily from a master list. These event dictionaries can then be easily saved and loaded instead of having to do a cumbersome process of decompiling the object into a dictionary and recompiling it into an object with the said dictionary.

Another benefit of doing this is that I can easily create a script to retroactively add more keys to the event dictionary and have everything work as intended.

To help with this, I also created a function in SaveManager called `Tuplefy2` which turns all lists in the dictionary back into a tuple for ScreenManager.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 