### PR TITLE
Pygame-RPG 21.8 Housekeeping and bugfixing

### DIFF
--- a/Rpg2.py
+++ b/Rpg2.py
@@ -136,8 +136,8 @@ npcManager = Entity.NPCManager(knight)
 saveManager = managers.SaveManager(knight, vars(), screenManager, eventManager, questManager, npcManager)
 itemManager = managers.ItemManager(knight)
 battleManager = Entity.BattleManager(knight, itemManager)
-UIManager = managers.UIManager(font, screen)
-UIHandler = managers.UIHandler(UIManager, saveManager, knight, vars(), battleManager, itemManager)
+uiManager = managers.UIManager(font, screen)
+uiHandler = managers.UIHandler(uiManager, saveManager, knight, vars(), battleManager, itemManager)
 
 
 
@@ -166,8 +166,8 @@ while True:
     keys = game.key.get_pressed()
     if start:
         screen.blit(screenManager.screen, (0, 0))
-        context, choice = UIManager.draw_UI(eventList)
-        UIHandler.handle_interaction(context, choice)
+        context, choice = uiManager.draw_UI(eventList)
+        uiHandler.handle_interaction(context, choice)
         if not start and choice == "Start Game":  # If it's not start game then context was already changed
             screenManager.change_context("Background1")
     else:
@@ -238,10 +238,10 @@ while True:
                 if len(battleManager.turnOrder) == 0:
                     battleManager.reset_turn_order()
                 if battleManager.turnOrder[0] == knight:
-                    if UIManager.UI is None:
-                        UIManager.change_UI("Player Select")  # Change the UI to the proper UI
-                    context, choice = UIManager.draw_UI(eventList)
-                    UIHandler.handle_interaction(context, choice)
+                    if uiManager.UI is None:
+                        uiManager.change_UI("Player Select")  # Change the UI to the proper UI
+                    context, choice = uiManager.draw_UI(eventList)
+                    uiHandler.handle_interaction(context, choice)
                     # See if the move selected is a valid move
                     if battleManager.moveDict.get(choice) is not None or itemManager.itemJson.get(choice) is not None:
                         buffered_move = choice  # set the buffered move
@@ -256,13 +256,13 @@ while True:
                             for i in range(battleManager.targetNum):
                                 targets.append(choice)
                         if len(targets) == battleManager.targetNum:  # check if we should leave targeting screen
-                            UIManager.change_UI(None)
+                            uiManager.change_UI(None)
                 returnable_strings, refresh = battleManager.do_one_turn(buffered_move, targets)
                 if refresh:
-                    UIManager.subMenuItems = itemManager.get_usable_items()  # refresh displayed
-                    UIManager.subMenuMaxIndex = len(UIManager.subMenuItems) - 1
-                    if UIManager.subMenuSlider >= len(UIManager.subMenuItems) and len(UIManager.subMenuItems) != 0:
-                        UIManager.subMenuSlider -= 1  # move slider back by 1
+                    uiManager.subMenuItems = itemManager.get_usable_items()  # refresh displayed
+                    uiManager.subMenuMaxIndex = len(uiManager.subMenuItems) - 1
+                    if uiManager.subMenuSlider >= len(uiManager.subMenuItems) and len(uiManager.subMenuItems) != 0:
+                        uiManager.subMenuSlider -= 1  # move slider back by 1
                 if len(returnable_strings) != 0:
                     # load the event strings into the dialogue list
                     dialogueManager.load_dialogue_list(returnable_strings)
@@ -286,7 +286,7 @@ while True:
                 # send them back to the start menu and reset their player character?
                 pass
             battleManager.battleState = (False, "")
-        UIManager.draw_health_bar(knight)
+        uiManager.draw_health_bar(knight)
         display_frame_rate(font, screen)
     game.display.update()
     clock.tick(60)

--- a/managers/Save_Manager.py
+++ b/managers/Save_Manager.py
@@ -3,14 +3,14 @@ from Entity.Knight import Knight
 from Entity.NPC_Manager import NPCManager
 import os, json
 class SaveManager:
-    def __init__(self, knight,  localVars, screenManager, eventManager, questManager, NPCManager, saveNumber=1):
+    def __init__(self, knight,  localVars, screenManager, eventManager, questManager, npcManager, saveNumber=1):
         self.knight = knight
         self.localVars = localVars
         self.screenManager = screenManager
         self.saveNumber = saveNumber
         self.eventManager = eventManager
         self.questManager = questManager
-        self.NPCManager = NPCManager
+        self.npcManager = npcManager
         self.limit = 4
         # Makes the initial save file
         
@@ -98,11 +98,11 @@ class SaveManager:
             "enemiesKilled": self.questManager.enemiesKilled,
             "npcsInteractedWith": self.questManager.npcsInteractedWith
         }
-        self.NPCManager.save_and_empty()  # save current changes to the dictionary
-        self.NPCManager.get_NPCs(self.screenManager.context)  # get the NPCs back
+        self.npcManager.save_and_empty()  # save current changes to the dictionary
+        self.npcManager.get_NPCs(self.screenManager.context)  # get the NPCs back
         newerdict = {"Knight": knightDict, "questManager": questManagerDict, "rawVariables": rawVarsDict,
                      "screenManager": screenManagerDict, "eventDict": self.eventManager.eventDict,
-                     "NPCDict": self.NPCManager.NPCDict}
+                     "NPCDict": self.npcManager.NPCDict}
         return newerdict
 
     def load_data(self, file):
@@ -114,8 +114,8 @@ class SaveManager:
         self.screenManager.objectDict = fileInfo["screenManager"]["objectDict"]
         self.screenManager.change_context(fileInfo["screenManager"]["context"])
         interactablesInfo = fileInfo["screenManager"]["interactablesDict"]
-        self.NPCManager.NPCDict = fileInfo["NPCDict"]  # set the NPC dict
-        self.NPCManager.get_NPCs(self.screenManager.context)  # reset the NPCs
+        self.npcManager.NPCDict = fileInfo["NPCDict"]  # set the NPC dict
+        self.npcManager.get_NPCs(self.screenManager.context)  # reset the NPCs
         self.eventManager.eventDict = fileInfo["eventDict"]
         # convert all lists to tuples in the dict
 

--- a/managers/UI_Handler.py
+++ b/managers/UI_Handler.py
@@ -27,9 +27,9 @@ vars_related_context = jsonInfo.get("vars_related_context")
 battle_related_context = jsonInfo.get("battle_related_context")
 class UIHandler():
     # The things UIHandler will need access to for user input
-    def __init__(self, UIManager, SaveManager, knight, localVars, battleManager, itemManager):
+    def __init__(self, uiManager, SaveManager, knight, localVars, battleManager, itemManager):
         # Dialogue Manager might have to be here too
-        self.UIManager = UIManager  # For changing the UI
+        self.uiManager = uiManager  # For changing the UI
         self.saveManager = SaveManager  # For saving and loading on UI
         self.knight = knight  # For access to inventory as well as battle interaction
         self.localVars = localVars  # For manipulating variables from player interaction
@@ -41,26 +41,26 @@ class UIHandler():
     def handle_interaction(self, context, choice):
         # submenu for battle
         if context == "Player Select" and choice in submenu_choice:
-            self.UIManager.subMenu = True
+            self.uiManager.subMenu = True
             if choice == "Skills":
                 # Get all the skills except for the first one ("Attack")
-                self.UIManager.subMenuItems = self.knight.moveList[1:]
+                self.uiManager.subMenuItems = self.knight.moveList[1:]
             elif choice == "Switch Stance":
-                self.UIManager.subMenuItems = ["Power", "Defensive", "Nimble",
+                self.uiManager.subMenuItems = ["Power", "Defensive", "Nimble",
                                                 "Power", "Defensive", "Nimble",
                                                 "Power", "Defensive", "Nimble",
                                                 "Power"]
 
             elif choice == "Items":
                 inventory = self.itemManager.get_usable_items()
-                self.UIManager.subMenuItems = inventory
+                self.uiManager.subMenuItems = inventory
 
         elif context is not None and choice is not None:
             #print(context)
             #print(choice)
             #print("..........................................")
             if [context, choice] in ui_related_context:
-                self.UIManager.change_UI(choice)  # Just change to the new UI
+                self.uiManager.change_UI(choice)  # Just change to the new UI
 
             elif context.find("(S)") != -1 or choice == "Attack":
                 if choice in stances:
@@ -84,9 +84,9 @@ class UIHandler():
                     else:
                         # add enemies to the list of targets
                         targetable = self.battleManager.get_enemy_positions()
-                    self.UIManager.targets = targetable
-                    self.UIManager.targetSlider = 0
-                    self.UIManager.change_UI("Select Target")
+                    self.uiManager.targets = targetable
+                    self.uiManager.targetSlider = 0
+                    self.uiManager.change_UI("Select Target")
 
 
                 # this is an attack of some sort
@@ -95,9 +95,9 @@ class UIHandler():
                     # Only go to targeting if the move can be used, if not the move cannot be selected
                     if self.battleManager.parse_restriction(self.knight, moveInfo) \
                             and self.knight.Mp >= moveInfo["Cost"]:
-                        self.UIManager.targets = self.battleManager.get_enemy_positions()
-                        self.UIManager.targetSlider = 0
-                        self.UIManager.change_UI("Select Target")
+                        self.uiManager.targets = self.battleManager.get_enemy_positions()
+                        self.uiManager.targetSlider = 0
+                        self.uiManager.change_UI("Select Target")
 
             elif context in save_related_context:
                 slot = choice.find("#")       # Finds the # character because the number is always next to it
@@ -109,7 +109,7 @@ class UIHandler():
                     if os.path.isfile(filePath):
                         self.saveManager.load(slot)
                         self.localVars.update({"start": False})  # Leave the Start screen (probably a better way for this)
-                        self.UIManager.change_UI(None)  # Clear UI
+                        self.uiManager.change_UI(None)  # Clear UI
                 # self.saveManager
                 pass
             elif context in knight_related_context:
@@ -122,7 +122,7 @@ class UIHandler():
                 # There's got to be a better way of dealing with this
                 if context == "Start" and choice == "Start Game":
                     self.localVars.update({"start": False})
-                    self.UIManager.change_UI(None)  # Clear UI
+                    self.uiManager.change_UI(None)  # Clear UI
                 elif context == "Start" and choice == "Continue":
                     slot = self.saveManager.saveNumber
                     # Implement a check to see if save has been tampered with for all save file loads
@@ -130,5 +130,5 @@ class UIHandler():
                     if flag:
                         self.saveManager.quick_load()  # Load the file
                         self.localVars.update({"start": False})  # Leave the Start screen
-                        self.UIManager.change_UI(None)  # Clear UI
+                        self.uiManager.change_UI(None)  # Clear UI
                     pass

--- a/managers/UI_Handler_test.py
+++ b/managers/UI_Handler_test.py
@@ -19,8 +19,8 @@ questManager = managers.QuestManager(dummyKnight)
 eventManager = managers.EventManager(dummyKnight, dialogueManager, questManager)
 npcManager = NPCManager(dummyKnight)
 saveManager = managers.SaveManager(dummyKnight, vars(), screenManager, eventManager, questManager, npcManager)
-UIManager = managers.UIManager(font, screen)
-UIHandler = managers.UIHandler(UIManager, saveManager, dummyKnight, vars(), battleManager, itemManager)
+uiManager = managers.UIManager(font, screen)
+UIHandler = managers.UIHandler(uiManager, saveManager, dummyKnight, vars(), battleManager, itemManager)
 
 # Variables I need for save manager
 start = True  # same as the variable that depends
@@ -31,72 +31,72 @@ gameState = ""
 x = 0
 
 def test_simulate_start_screen():
-    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    context, choice = uiManager.draw_UI(get_keydown_event("enter"))  # press start
     UIHandler.handle_interaction(context, choice)
     # Start should be false and UIManager vars should be cleared
-    assert not start and UIManager.UI is None and len(UIManager.prevUIs) == 0 and choice == "Start Game"
+    assert not start and uiManager.UI is None and len(uiManager.prevUIs) == 0 and choice == "Start Game"
 
 def test_simulate_continue_selection():
     UIHandler.localVars.update({"start": True})  # Reset start to true
-    UIManager.change_UI("Start")  # Reset UIManager
-    UIManager.draw_UI(get_keydown_event("s"))        # Move down 1
-    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    uiManager.change_UI("Start")  # Reset UIManager
+    uiManager.draw_UI(get_keydown_event("s"))        # Move down 1
+    context, choice = uiManager.draw_UI(get_keydown_event("enter"))  # press start
     UIHandler.handle_interaction(context, choice)
-    assert not start and UIManager.UI is None and len(UIManager.prevUIs) == 0 and choice == "Continue"
+    assert not start and uiManager.UI is None and len(uiManager.prevUIs) == 0 and choice == "Continue"
 
 def test_simulate_move_to_load_screen():
-    UIManager.change_UI("Start")  # Reset UIManager
-    UIManager.draw_UI(get_keydown_event("s"))        # Move down 1
-    UIManager.draw_UI(get_keydown_event("s"))        # Move down 1
-    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    uiManager.change_UI("Start")  # Reset UIManager
+    uiManager.draw_UI(get_keydown_event("s"))        # Move down 1
+    uiManager.draw_UI(get_keydown_event("s"))        # Move down 1
+    context, choice = uiManager.draw_UI(get_keydown_event("enter"))  # press start
     UIHandler.handle_interaction(context, choice)
     #  UI should change and the previous UI is added to prevUIs
-    assert UIManager.UI == "Load Game" and len(UIManager.prevUIs) > 0 and UIManager.prevUIs[0] == "Start"
+    assert uiManager.UI == "Load Game" and len(uiManager.prevUIs) > 0 and uiManager.prevUIs[0] == "Start"
 
 def test_simulate_load_fail():
     # Assume slot 2 is empty
     UIHandler.localVars.update({"start": True})  # Reset start to true
-    UIManager.draw_UI(get_keydown_event("s"))    # Move down 1
-    context, choice = UIManager.draw_UI(get_keydown_event("enter"))  # press start
+    uiManager.draw_UI(get_keydown_event("s"))    # Move down 1
+    context, choice = uiManager.draw_UI(get_keydown_event("enter"))  # press start
     UIHandler.handle_interaction(context, choice)
-    assert start and UIManager.UI == "Load Game"  # We haven't moved screens and start isn't switched off
+    assert start and uiManager.UI == "Load Game"  # We haven't moved screens and start isn't switched off
 
 def test_simulate_load_success():
     # Assume slot 1 isn't empty since save manager tests should fill it
-    UIManager.draw_UI(get_keydown_event("w"))        # Move up 1
-    context, choice = UIManager.draw_UI(get_keydown_event("enter"))    # Press enter
+    uiManager.draw_UI(get_keydown_event("w"))        # Move up 1
+    context, choice = uiManager.draw_UI(get_keydown_event("enter"))    # Press enter
     UIHandler.handle_interaction(context, choice)
-    assert not start and UIManager.UI is None  # Load Succeeds
+    assert not start and uiManager.UI is None  # Load Succeeds
 
 def test_simulate_targeting_transition():
     battleManager.add_enemy(factory.create_entity("dummy"))
-    UIManager.change_UI("Player Select", False)  # change the UI to targeting
+    uiManager.change_UI("Player Select", False)  # change the UI to targeting
     eventList = get_keydown_event("enter")  # press enter
-    context, choice = UIManager.draw_UI(eventList)  # process events
+    context, choice = uiManager.draw_UI(eventList)  # process events
     UIHandler.handle_interaction(context, choice)  # handle the interaction
     # check if the UI changed and if the position is the same
-    assert UIManager.UI == "Select Target" and UIManager.targets[0] == battleManager.enemies[0][0]
+    assert uiManager.UI == "Select Target" and uiManager.targets[0] == battleManager.enemies[0][0]
 
 def test_simulate_skill_use():
     dummyKnight.moveList.append("Super Attack")  # give dummy knight an unusable skill
     dummyKnight.moveList.append("Pilfering Strike")  # give dummy knight a usable skill
     eventList = get_keydown_event("esc")  # press escape
-    UIManager.draw_UI(eventList)  # process events
+    uiManager.draw_UI(eventList)  # process events
     eventList = get_keydown_event("s")  # go down 1
-    UIManager.draw_UI(eventList)  # process events
+    uiManager.draw_UI(eventList)  # process events
     eventList = get_keydown_event("enter")  # press enter
-    context, choice = UIManager.draw_UI(eventList)  # process events
+    context, choice = uiManager.draw_UI(eventList)  # process events
     UIHandler.handle_interaction(context, choice)  # handle the interaction
-    flag = UIManager.subMenu  # check if the submenu is active
+    flag = uiManager.subMenu  # check if the submenu is active
     eventList = get_keydown_event("enter")  # press enter
-    context, choice = UIManager.draw_UI(eventList)  # process events
+    context, choice = uiManager.draw_UI(eventList)  # process events
     UIHandler.handle_interaction(context, choice)  # handle the interaction
     # the UI shouldn't have changed
-    flag2 = UIManager.UI == "Player Select" and choice == "Super Attack"
+    flag2 = uiManager.UI == "Player Select" and choice == "Super Attack"
     eventList = get_keydown_event("d")  # move 1 to the right
-    UIManager.draw_UI(eventList)  # process events
+    uiManager.draw_UI(eventList)  # process events
     eventList = get_keydown_event("enter")  # press enter
-    context, choice = UIManager.draw_UI(eventList)  # process events
+    context, choice = uiManager.draw_UI(eventList)  # process events
     UIHandler.handle_interaction(context, choice)  # handle the interaction
-    flag3 = UIManager.UI == "Select Target" and choice == "Pilfering Strike"
+    flag3 = uiManager.UI == "Select Target" and choice == "Pilfering Strike"
     assert flag and flag2 and flag3


### PR DESCRIPTION
### Pygame-RPG 21.8 Housekeeping and bugfixing

This PR is about changing the names of the class variables so that they don't mirror the name of their class. This is really only a problem for the following classes. `NPCManager`, `UIManager` and `UIHandler`.

Because of this, the names of the object for those classes will be changed to the following.

`NPCManager` -> `npcManager`
`UIManager` -> `uiManager`
`UIHandler` -> `uiHandler`

This way, it will be obvious when we are referring to the class and when we're referring to the object.


## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 