### PR TITLE
Pygame-RPG 21.11 Optimizing Sprite classes

### DIFF
--- a/Entity/Knight.py
+++ b/Entity/Knight.py
@@ -32,7 +32,10 @@ class Knight(Entity):
         }
 
     def set_image_and_rect(self):
-        filePath = self.Sprite + "Knight_" + self.aniStatus + "_" + str((self.aniTracker // 10) + 1) + ".png"
+        spot = str((self.aniTracker // 10) + 1)  # the frame of the animation
+        if self.aniTracker == -1:  # check if we have a -1
+            spot = str(self.maxAniVal)  # set the spot to the max
+        filePath = self.Sprite + self.Name + "_" + self.aniStatus + "_" + spot + ".png"  # create the file path
         self.image = game.image.load(filePath)  # load the new image
         if self.flipped:  # if the run is to be flipped
             self.image = game.transform.flip(self.image, True, False)  # flip across y axis
@@ -40,13 +43,14 @@ class Knight(Entity):
         self.rect = self.image.get_rect()  # get the new rectangle
         self.rect.center = (self.x, self.y)  # center the rectangle to the players coordinates
 
-    def update(self):
+    def update(self, force=False):
         # this behavior is for overworld behavior
-        self.aniTracker += 1  # increment the tracker
-        if self.aniTracker % 10 == 0:  # every 10 frames we shift the animation
+        if self.aniTracker != -1:  # -1 means that the animation is stuck for it
+            self.aniTracker += 1  # increment the tracker
+        if self.aniTracker % 10 == 0 or force:  # every 10 frames we shift the animation or if we force it
             update = False  # indicator for if an update is needed
             if (self.aniTracker // 10) + 1 > self.maxAniVal and self.aniStatus == "Death":
-                self.aniTracker = self.maxAniVal * 10  # set it to the max value
+                self.aniTracker = -1  # set it so that it can't change
             elif (self.aniTracker // 10) + 1 > self.maxAniVal:
                 self.aniTracker = 0  # reset animation timer
                 update = True  # indicate that an update is needed

--- a/Entity/NPC.py
+++ b/Entity/NPC.py
@@ -31,12 +31,17 @@ class NPC(game.sprite.Sprite):
         self.rect.center = self.Pos  # set the new pos
 
     # simpler version of the Entity update function
-    def update(self):
+    def update(self, force=False):
         self.aniTracker += 1  # increment the tracker
-        if self.aniTracker % 10 == 0:  # every 10 frames we shift the animation
+        if self.aniTracker % 10 == 0 or force:  # every 10 frames we shift the animation or when we force it
+            update = False
             if (self.aniTracker // 10) + 1 > self.maxAniVal:
                 self.aniTracker = 0  # reset animation timer
-            self.set_image_and_rect()  # if the above condition is triggered we know an update is going to happen
+                update = True  # indicate that an update is needed
+            elif (self.aniTracker // 10) + 1 <= self.maxAniVal:
+                update = True  # indicate that an update is needed
+            if update:  # check if we need to update
+                self.set_image_and_rect()  # if the above condition is triggered we know an update is going to happen
 
     def add_event_keys(self, events):
         self.Dialogue += events  # add the events to the NPCs dialogue queue

--- a/Entity/NPC_Manager.py
+++ b/Entity/NPC_Manager.py
@@ -19,6 +19,8 @@ class NPCManager:
     def save_and_empty(self):
         # saves the changed NPC information and then empties the Sprite Group
         for sprite in self.NPCGroup.sprites():
+            if (sprite.aniTracker // 10) + 1 > sprite.maxAniVal:  # check if the aniTracker value is valid
+                sprite.update(True)  # force update
             self.NPCDict[sprite.Name]["Dialogue"] = sprite.Dialogue  # update the dialogue list
         self.NPCGroup.empty()  # remove all sprites from the group
 

--- a/Entity/NPC_test.py
+++ b/Entity/NPC_test.py
@@ -15,10 +15,12 @@ def test_update():
     npc.update()
     # check if rect and image were set and confirm this happened on the tenth frame
     flag2 = npc.rect is not None and npc.image is not None and npc.aniTracker == 10
-    npc.aniTracker = (npc.maxAniVal * 10) + 9  # a number that exceeds the max and is 1 tick away from an update
+    npc.aniTracker = (npc.maxAniVal * 10) + 5  # a number that ISN'T going to trigger the update
     npc.update()  # update the sprite
-    flag3 = npc.aniTracker == 0  # check to see if the tracker was reset
-    assert flag and flag2 and flag3
+    flag3 = npc.aniTracker == (npc.maxAniVal * 10) + 6  # check to see if aniTracker was upped
+    npc.update(True)  # force the update
+    flag4 = npc.aniTracker == 0  # check to see if the tracker was reset
+    assert flag and flag2 and flag3 and flag4
 
 def test_add_events():
     oldEvents = npc.Dialogue.copy()  # a copy of the old events

--- a/Entity/Object.py
+++ b/Entity/Object.py
@@ -25,7 +25,10 @@ class Object(game.sprite.Sprite):
         return Utils.get_max_animation_val(self.Sprite, self.ObjectType, self.aniStatus)
 
     def set_image_and_rect(self):
-        filePath = self.Sprite + self.ObjectType + "_" + self.aniStatus + "_" + str((self.aniTracker // 10) + 1) + ".png"
+        spot = str((self.aniTracker // 10) + 1)  # the frame of the animation
+        if self.aniTracker == -1:  # check if we have a -1
+            spot = str(self.maxAniVal)  # set the spot to the max
+        filePath = self.Sprite + self.ObjectType + "_" + self.aniStatus + "_" + spot + ".png"  # create the file path
         self.image = game.image.load(filePath)  # load the new image
         self.image = game.transform.scale(self.image, self.Scale)  # scale the image to a set value
         if self.Flipped:  # check if the image is supposed to be flipped
@@ -33,12 +36,13 @@ class Object(game.sprite.Sprite):
         self.rect = self.image.get_rect()  # get the new
         self.rect.center = self.Pos  # set the new pos
 
-    def update(self):
-        self.aniTracker += 1  # increment the tracker
-        if self.aniTracker % 10 == 0:  # every 10 frames we shift the animation
+    def update(self, force=False):
+        if self.aniTracker != -1:  # -1 indicates that it can't change
+            self.aniTracker += 1  # increment the tracker
+        if self.aniTracker % 10 == 0 or force:  # every 10 frames we shift the animation or when we force it
             update = False  # flag for when we should update the image and rect
             if (self.aniTracker // 10) + 1 > self.maxAniVal and self.aniStatus == "Opening":
-                self.aniTracker = self.maxAniVal * 10 - 10  # set it to the max already
+                self.aniTracker = -1  # make it stuck on the final animation
             elif (self.aniTracker // 10) + 1 > self.maxAniVal:
                 self.aniTracker = 0  # reset animation timer
                 update = True  # we need to update the sprite

--- a/Entity/Object_Manager.py
+++ b/Entity/Object_Manager.py
@@ -20,7 +20,7 @@ class ObjectManager:
             objDict = self.objectDict[object.Name]
             # updates the dictionary key/value pairs for the current object
             if (object.aniTracker // 10) + 1 > object.maxAniVal:  # check if the tracker is invalid
-                object.update()  # update the sprite so it can handle it
+                object.update(True)  # force the sprite info to update
             objDict.update({
                 "Events": object.Events,
                 "aniStatus": object.aniStatus,

--- a/Entity/Object_Manager_test.py
+++ b/Entity/Object_Manager_test.py
@@ -18,10 +18,13 @@ def test_create_object():
 def test_save_and_empty():
     obj = objectManager.create_object("testObject")  # create a test object
     obj.Events = []  # set it to an empty list
+    # make it so that it's past the limit but doesn't trigger the interval normally
+    obj.aniTracker = obj.maxAniVal * 10 + 1
     objectManager.objectGroup.add(obj)  # add the object to the group
     objectManager.save_and_empty()  # save and empty the changes
     obj = objectManager.create_object("testObject")  # create a test object
-    assert obj.Events == []  # check to see if the change stayed
+    # aniTracker is 0 because it isn't opening, otherwise it would be -1
+    assert obj.Events == [] and obj.aniTracker == 0  # check to see if the changes stayed
 
 def test_get_objects():
     objectManager.get_objects("INVALID")  # give in a context that makes no sense

--- a/Entity/Object_test.py
+++ b/Entity/Object_test.py
@@ -6,17 +6,25 @@ obj = Object(objectDict["testObject"])
 
 def test_update():
     obj.update()  # update the sprite
-    flag = obj.aniTracker == 1
-    obj.aniTracker = obj.maxAniVal * 10 + 9
+    flag = obj.aniTracker == 1  # check to see if it updated
+    obj.aniTracker = obj.maxAniVal * 10 + 9  # set it to hit the interval next update
+    obj.image = None
+    obj.rect = None
     obj.update()  # update the sprite
-    flag2 = obj.aniTracker == 0  # see if the tracker reset
+    # check to see if the image and sprite were updated
+    flag2 = obj.aniTracker == 0 and obj.image is not None and obj.rect is not None
     obj.aniStatus = "Opening"  # change the status
     obj.maxAniVal = obj.get_max_animation_val()  # reset the maximum animation value
-    obj.aniTracker = obj.maxAniVal * 10 + 9
+    obj.aniTracker = obj.maxAniVal * 10 + 5
     obj.update()  # update the sprite
+    # tracker got updated but the condition didn't trigger (not in interval)
+    flag3 = obj.aniTracker = obj.maxAniVal * 10 + 6  # check if the tracker just updated normally
+    obj.update(True)  # force the update
     # treasure chest specific attribute
-    flag3 = obj.aniTracker == obj.maxAniVal * 10 - 10  # should be stuck on this
-    assert flag and flag2 and flag3
+    flag4 = obj.aniTracker == -1  # should be stuck on this
+    obj.update()  # try to update the aniTracker variable
+    flag5 = obj.aniTracker == -1
+    assert flag and flag2 and flag3 and flag4 and flag5
 
 def test_get_event_key():
     key = obj.get_event_key()

--- a/JSON/Events/Events.json
+++ b/JSON/Events/Events.json
@@ -90,7 +90,7 @@
       "Range": [],
       "Event Type": "Dialogue",
       "Activated": false,
-      "Repeatable": false,
+      "Repeatable": true,
       "Dialogue Path": "event_text/chestEmpty.txt",
       "Quest": "",
       "Context": "",

--- a/managers/Save_Manager.py
+++ b/managers/Save_Manager.py
@@ -61,6 +61,8 @@ class SaveManager:
         # Animation trackers are saved because removing them might cause a weird edge case
         allowed = ["animationTracker", "animationTracker2", "animationTracker3", "gameState"]
         rawVarsDict = {}  # The raw values I need for the game (stuff in allowed)
+        if (self.knight.aniTracker // 10 + 1) > self.knight.maxAniVal:  # check to see if Knight has an illegal value
+            self.knight.update(True)  # force the update
         knightDict = {
             "fieldStatus": self.knight.fieldStatus,
             "aniStatus": self.knight.aniStatus,


### PR DESCRIPTION
### Pygame-RPG 21.11 Optimizing Sprite classes
Since I made the sprite classes fairly quickly, this PR is to iron out some flaws with them. One such flaw is how they update, their `update()` function. Because I made them so that they only check the value of `aniTracker` once every 10 frames, it is possible for a class that inherits from `Sprite` class to have a fault `aniTracker` value that was saved. Since this game runs at 60 fps, it's improbable but possible.

As a result, I added a default value to update called `force`. `force` is set to false normally so when the groups call the function, it'll behave as normal. If a value of `True` is given to the function however, it will bypass the `aniTracker % 10 == 0` conditional and execute the rest of the code. This ensures that the `aniTracker` attribute will always be an allowed value i.e. never surpassing the limit. This is going to be called during the `save_and_empty()` functions for the `NPC` and `Object` classes. As for the `Knight` class, there is a conditional that checks to see if the `aniTracker` value is out of the range and then if the conditional is true, forces an update.

Because the `NPC` class allows forced updates, to stop unnecessary calls to `set_image_and_rect()` the function is a lot more explicit in it's conditions, resembling the conditionals in the `update()` functions of the `Object` and `Knight` classes.

A new change to the `update()` function for the `Knight` and `Object` class was that if the `aniTracker` value is set to -1, that indicates that the state the object is in is permanent. If this is the case, the `aniTracker` value will no longer update and the sprite cannot be changed. This is useful for the "Death" animation status for the `Knight` class and the "Opening" animation status for the `Object` class. Because of this, the `set_image_and_rect()` function for both of these classes needed to be tweaked.

If the `aniTracker` value is -1 and is saved, the next time the image is loaded, the `set_image_and_rect()` function will check for this. If this is the case, it will set the "spot" variable to the string value of `maxAniVal`. This "spot" will be used in the file path to the png in use.

I also updated the "chestEmpty" event in the `Events.json` file to be repeatable. As always, the tests have been updated to fit these new behaviors and test them.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 