### PR TITLE
Pygame-RPG 25 Integrating Animation Manager

### DIFF
--- a/Entity/Enemy.py
+++ b/Entity/Enemy.py
@@ -6,6 +6,7 @@ class Enemy(Entity):
                         jsonInfo["Sprite"], jsonInfo["Lvl"], jsonInfo["Str"], jsonInfo["Mag"], jsonInfo["Vit"],
                         jsonInfo["Agl"], jsonInfo["Def"], jsonInfo["Exp"], jsonInfo["Money"],
                         jsonInfo["Inventory"])
+        self.Scale = tuple(jsonInfo["Scale"])
         self.flipped = jsonInfo["flipped"]
         self.moveList = jsonInfo["moveList"]
         self.uniqueBuff = jsonInfo["uniqueBuff"]  # For bosses only really

--- a/Entity/Entities_test.py
+++ b/Entity/Entities_test.py
@@ -166,7 +166,7 @@ def test_create_entity():
     entity1 = factory.create_entity(name)
     entity2 = factory.create_entity(name)
     # check the names
-    flag = entity1.Name == name and entity2.Name == (name + "2")
+    flag = entity1.altName == name and entity2.altName == (name + "2")
     assert flag and factory.createdCount[name] == 2
 
 def test_clear_created_count():

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -8,7 +8,9 @@ class Entity(game.sprite.Sprite):
         if inventory is None:
             inventory = {}  # Inventory is a dictionary of it with key pairs (string: int)
         self.Name = name
+        self.altName = self.Name  # alternative name
         self.Sprite = sprite
+        self.Scale = ()
         self.Status = ("Normal", -1)
         self.Lvl = level
         self.Hpcap = Hpcap
@@ -50,7 +52,7 @@ class Entity(game.sprite.Sprite):
         self.image = game.image.load(filePath)  # load the new image
         if self.flipped:  # if the run is to be flipped
             self.image = game.transform.flip(self.image, True, False)  # flip across y axis
-        self.image = game.transform.scale(self.image, (450, 300))  # scale the image
+        self.image = game.transform.scale(self.image, self.Scale)  # scale the image
         self.rect = self.image.get_rect()  # get the new rectangle
         self.rect.center = (self.x, self.y)  # center the rectangle to the players coordinates
 

--- a/Entity/Entity_Factory.py
+++ b/Entity/Entity_Factory.py
@@ -17,7 +17,7 @@ class EntityFactory:
             self.createdCount.update({name: 1})
         else:
             self.createdCount[name] += 1  # increment the value by 1
-            enemy.Name = enemy.Name + str(self.createdCount[name])  # add the number to the name
+            enemy.altName = enemy.Name + str(self.createdCount[name])  # add the number to the name
         return enemy  # return enemy
 
     def clear_created_count(self):

--- a/Entity/Knight.py
+++ b/Entity/Knight.py
@@ -6,6 +6,7 @@ class Knight(Entity):
     # The current stats still need to be changed to the default stats later
     def __init__(self, Hp=1, Hpcap=1, Mp=1, Mpcap=1, name="Knight", sprite="Entity_Sprites/Knight/", level=1, strength=1, magic=1, vitality=1, agility=1, defence=1, exp=0, expcap=1, money=0):
         super().__init__(Hp, Hpcap, Mp, Mpcap, name, sprite, level, strength, magic, vitality, agility, defence, exp, money)
+        self.Scale = (450, 300)
         self.fieldStatus = "Normal"  # indicator for the knight class
         self.Expcap = expcap
         self.Stance = "1"

--- a/JSON/Enemies/Dragon.json
+++ b/JSON/Enemies/Dragon.json
@@ -5,6 +5,7 @@
    "Mpcap": 1,
    "Name": "Dragon",
    "Sprite": "Entity_Sprites/",
+   "Scale": [140, 140],
    "flipped": false,
    "Lvl": 1,
    "Str": 1,

--- a/JSON/Enemies/Gargoyle.json
+++ b/JSON/Enemies/Gargoyle.json
@@ -5,6 +5,7 @@
    "Mpcap": 1,
    "Name": "Gargoyle",
    "Sprite": "Entity_Sprites/",
+   "Scale": [158, 125],
    "flipped": false,
    "Lvl": 1,
    "Str": 1,

--- a/JSON/Enemies/Goblin.json
+++ b/JSON/Enemies/Goblin.json
@@ -5,6 +5,7 @@
    "Mpcap": 1,
    "Name": "Goblin",
    "Sprite": "Entity_Sprites/Goblin/",
+   "Scale": [232, 156],
    "flipped": false,
    "Lvl": 1,
    "Str": 1,

--- a/JSON/Enemies/Kobold.json
+++ b/JSON/Enemies/Kobold.json
@@ -5,6 +5,7 @@
    "Mpcap": 1,
    "Name": "Kobold",
    "Sprite": "Entity_Sprites/Kobold/",
+   "Scale": [148, 96],
    "flipped": false,
    "Lvl": 1,
    "Str": 1,

--- a/JSON/Enemies/Minotaur.json
+++ b/JSON/Enemies/Minotaur.json
@@ -5,6 +5,7 @@
    "Mpcap": 1,
    "Name": "Minotaur",
    "Sprite": "Entity_Sprites/",
+   "Scale": [128, 128],
    "flipped": false,
    "Lvl": 1,
    "Str": 1,

--- a/JSON/Enemies/Werewolf.json
+++ b/JSON/Enemies/Werewolf.json
@@ -5,6 +5,7 @@
    "Mpcap": 1,
    "Name": "Werewolf",
    "Sprite": "Entity_Sprites/",
+   "Scale": [158, 125],
    "flipped": false,
    "Lvl": 1,
    "Str": 1,

--- a/JSON/Enemies/dummy.json
+++ b/JSON/Enemies/dummy.json
@@ -5,6 +5,7 @@
    "Mpcap": 999,
    "Name": "dummy",
    "Sprite": "Entity_Sprites/dummy/",
+   "Scale": [140, 140],
    "flipped": false,
    "Lvl": 1,
    "Str": 999,

--- a/JSON/Moves/Complete_Move_List.json
+++ b/JSON/Moves/Complete_Move_List.json
@@ -1,4 +1,19 @@
 {
+   "Use Item": {
+      "Damage Calculation": "",
+      "Type": "",
+      "Cost": 0,
+      "Restriction": null,
+      "Effect": null,
+      "AOE": false,
+      "Target Number": 1,
+      "Probability": null,
+      "Weight": 100,
+      "Attack Type": "",
+      "Animation Status": "Attack1",
+      "Alternative": "Attack1",
+      "Description": "Default move when the player uses an item"
+   },
    "Attack": {
       "Damage Calculation": "Str * 0.8",
       "Type": "Attack",

--- a/Scripts.py
+++ b/Scripts.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
             "Mpcap": 1,
             "Name": arg2,
             "Sprite": "Entity_Sprites/",
+            "Scale": (),
             "flipped": False,
             "Lvl": 1,
             "Str": 1,

--- a/Utils/Algos.py
+++ b/Utils/Algos.py
@@ -16,3 +16,10 @@ def get_max_animation_val(sprite, name, aniStatus):
 def sort_func(e):
     final = e.replace(".png", "")  # get rid of the png portion of the file name
     return int(final.split("_").pop())  # get the maximum number
+
+def get_others(actor, selectedTargets, targets):
+    others = []
+    for target in targets:
+        if target not in selectedTargets and target != actor:
+            others.append(target)
+    return others

--- a/managers/Item_Manager_test.py
+++ b/managers/Item_Manager_test.py
@@ -1,10 +1,14 @@
 from Entity import Knight
+from Entity import AnimationManager
 from managers import ItemManager
 from managers import BattleManager
-
+import pygame as game
+game.init()
+screen = game.display.set_mode((1422, 800))
 knight = Knight()
 
 itemManager = ItemManager(knight)
+animationManager = AnimationManager(screen)
 
 
 def test_determine_limited():
@@ -115,7 +119,7 @@ def test_fuse_items():
 
 def test_item_compatibility():
     # this series of tests checks if the item effects can be parsed by battleManager
-    battleManager = BattleManager(knight, itemManager)  # init BattleManager
+    battleManager = BattleManager(knight, itemManager, animationManager)  # init BattleManager
     staticHealingEffect = itemManager.get_effect("Potion")  # get an effect string that heals the user by X amount
     percentageHealingEffect = itemManager.get_effect("Dragon Tear")  # get an effect that heals on a percentage
     burnHealEffect = itemManager.get_effect("Ointment")  # get the effect to heal Burn

--- a/managers/UI_Handler_test.py
+++ b/managers/UI_Handler_test.py
@@ -3,6 +3,7 @@ import pygame as game
 from managers.UI_Manager_test import get_keydown_event
 from Entity.NPC_Manager import NPCManager
 from Entity.Object_Manager import ObjectManager
+from Entity.Animation_Manager import AnimationManager
 
 game.init()
 
@@ -14,7 +15,8 @@ screenManager = managers.ScreenManager(screen)
 dummyKnight = managers.Knight()
 factory = managers.EntityFactory()
 itemManager = managers.ItemManager(dummyKnight)
-battleManager = managers.BattleManager(dummyKnight, itemManager)
+animationManager = AnimationManager(screen)
+battleManager = managers.BattleManager(dummyKnight, itemManager, animationManager)
 dialogueManager = managers.DialogueManager(font, screen)
 questManager = managers.QuestManager(dummyKnight)
 eventManager = managers.EventManager(dummyKnight, dialogueManager, questManager)

--- a/managers/UI_Manager.py
+++ b/managers/UI_Manager.py
@@ -257,7 +257,9 @@ class UIManager:
                 # validate targetSlider pos and draw cursor
                 if self.targetSlider > len(self.targets) - 1 or self.targetSlider < 0:
                     self.targetSlider = oldSliderVal
-                self.screen.blit(self.cursor.cursor, self.targets[self.targetSlider])
+                pos = self.targets[self.targetSlider]  # the position we blit
+                pos = (pos[0] - 100, pos[1] - 20)  # apply offsets
+                self.screen.blit(self.cursor.cursor, pos)
         else:
             flag = self.cursor.handle_cursor(keys)
             # If a selection is made, find out which option was selected


### PR DESCRIPTION
### Pygame-RPG 25 Integrating Animation Manager
This PR focuses on integrating the `AnimationManager` class into the `Rpg2.py` file. First however, there were other changes in other files that needed to be made.

`Entity`:
This class received 2 new attributes, `altName` and `Scale`, `altName` is a string that's an alternative to the `Name` attribute. The reason for this division is that `Name` is used for animation so it can't be changed but sometimes we do want to call objects by a different name to differentiate them (for example in combat "Goblin" and "Goblin2"). Scale, is a tuple that represents the size and width of the sprite. This works the same as the `Scale` attribute found in `Interactable`.

`Enemy`:
This class now takes in the `Scale` attribute from the JSON file

`Knight`:
now has a set `Scale` attribute on init

`EntityFactory`: When using the `create_entity()` functions, the function no longer changes the `Name` attribute but the `altName` attribute.

`AnimationManager`:
This class received many changes for the sake of the integration. Below are the notable changes.

`use_slope_equation()`: The condition for checking if the equation is proper is changed to instead see if a starting point was present since the `m`, `b` keys can be 0. `x_distance` also doesn't need to be checked since it is set when the `startingPoint` key is set.

`load_action_queue()`: When this function is called, it now sects the `active` attribute to True. The point the actor goes to for a "Physical" attack is now changed to be dependent on an the inequality based on the x coordinate of the actor and the target. If the x coordinate of the actor is greater than the target. The way the "ranged" attack point is also slightly different.

`partial_reset_action()`: A new function that resets some attributes while leaving others. This is used when an action has been completed.

`reset_action()`:
A null check for the actor is added for when we attempt to call `change_targets_animation()` during this function. This change is just so that tests don't fail in `BattleManager`.

`process_action()`: The manager now resets everything when the queue runs out of actions. The `use_slope_equation()` is null checked. Finally, the `partial_reset_action()` function is called when the `frameCount` reaches the `maxFrameCount`

`Algos.py`: This file received a new function called `get_others()`: This function takes in a Sprite actor, list of Sprites and a list of all Sprites. It then bassically creates a list of sprites that isn't the actor and isn't in the list of selected targets.

`BattleManager`:
`BattleManager` now takes in a reference to the animationManager object. and there were some changes made to the functions in the class.

`add_enemy()`: The function now centers the entity on the changed x and y coordinates.

`do_one_turn()`: This function now calls the `load_animation_queue()` function from `AnimationManager` when a proper move has been made. Also, the `get_others()` function is used to get the uninvolved Entities.

The final change for the `BattleManager` class is that all returnable strings now use `altName` instead of `Name`.

`Rpg2.py`: To support the `AnimationManager` class, the mock battle code has been changed to make more sense. Finally, a condition to check whether the `AnimationManager` is in use or the `BattleManager` is in use. When the `AnimationManager` is in use, the `DialogueManager` is also in use, meaning the dialogue and the animations run at the same time. When the animation is done, the `BattleManager` part of the code is run and when a move is made, the `AnimationManager` gets a turn.

Other Changes:
- Updates to JSON Schema
- Updates to testing files
- Slight change to how the cursor is displayed in `UIManager` for the "Select Targets" screen

# Note
There's a known issue with when items are used in a battle that needs to be addressed in the next PR

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 