### PR TITLE
Pygame-RPG 25.1 Housekeeping and bugfixing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ event_text/strip.py
 event_text/Parse.py
 test.py
 ui_test.py
+.idea

--- a/.idea/WinterProject.iml
+++ b/.idea/WinterProject.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.12" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12" project-jdk-type="Python SDK" />
 </project>

--- a/Entity/Animation_Manager.py
+++ b/Entity/Animation_Manager.py
@@ -71,7 +71,8 @@ class AnimationManager:
 
     def fill_sprite_group(self, entities):
         for entity in entities:
-            self.spriteGroup.add(entity)  # add the entity
+            if entity not in self.spriteGroup.sprites():  # only allow unique entries
+                self.spriteGroup.add(entity)  # add the entity
 
     def change_targets_animation(self, sprites, aniStatus):
         for entity in sprites:
@@ -82,7 +83,7 @@ class AnimationManager:
                 entity.aniStatus = aniStatus  # change the animation
                 entity.reset_max_animation_val()  # reset the max animation for the new animation
 
-    def load_action_queue(self, move, actor, targets, others):
+    def load_action_queue(self, actionInfo, actor, targets, others):
         self.active = True  # set the active attribute to true
         self.actor = actor  # main actor
         if len(targets) == 1 and targets[0] == actor:
@@ -94,14 +95,7 @@ class AnimationManager:
         self.fill_sprite_group(targets)  # add in the targets
         self.fill_sprite_group([self.actor])  # add in the actor
         self.actorStartingPos = (self.actor.x, self.actor.y)  # starting position for actor
-        attackType = move.attackType  # the type of attack
-        moveAction = {
-            "type": move.type,
-            "aniStatus": move.aniStatus,
-            "alternative": move.alternative,
-            "flipped": False,
-            "point": None
-        }
+        attackType = actionInfo.pop("attack type")  # get the type of attack and remove it from the dict
         if attackType != "":  # confirm that there is movement
             runningToDict = {
                 "type": "",
@@ -125,14 +119,14 @@ class AnimationManager:
                 point = (711, 400)  # some defined midpoint
             runningToDict.update({"point": point})  # update the point key
             self.actionQueue.append(runningToDict)  # add this to the queue
-            self.actionQueue.append(moveAction)  # the actual attack animation
+            self.actionQueue.append(actionInfo)  # the actual attack animation
             runningBackDict.update({  # update the running back dict
                 "flipped": True,
                 "point": self.actorStartingPos
             })
             self.actionQueue.append(runningBackDict)  # add the running back to the queue
         else:
-            self.actionQueue.append(moveAction)  # add the actual attack animation
+            self.actionQueue.append(actionInfo)  # add the actual attack animation
 
     def apply_new_action(self):
         # check if the animation we want to set it to is available

--- a/Entity/Animation_Manager_test.py
+++ b/Entity/Animation_Manager_test.py
@@ -93,10 +93,10 @@ def test_change_animation_target():
 
 def test_load_action_queue():
     # set up the moves
-    rangedMove = Move("Double Slash", knight, moveDict["Double Slash"])
-    nonAttackMove = Move("Defensive Stance", knight, moveDict["Defensive Stance"])
-    physicalMove = Move("Attack", knight, moveDict["Attack"])
-    aoeMove = Move("Spinning Slash", knight, moveDict["Spinning Slash"])
+    rangedMove = Move("Double Slash", knight, moveDict["Double Slash"]).get_action_details()
+    nonAttackMove = Move("Defensive Stance", knight, moveDict["Defensive Stance"]).get_action_details()
+    physicalMove = Move("Attack", knight, moveDict["Attack"]).get_action_details()
+    aoeMove = Move("Spinning Slash", knight, moveDict["Spinning Slash"]).get_action_details()
     # load the ranged move
     animationManager.load_action_queue(rangedMove, knight, [goblin], [dummy])
     # check the actor details

--- a/Entity/Move.py
+++ b/Entity/Move.py
@@ -17,6 +17,17 @@ class Move:
         self.alternative = jsonInfo["Alternative"]  # the animation to play if the sprite doesn't have the animation
         self.description = jsonInfo["Description"]  # Description of the attack being used
 
+    def get_action_details(self):
+        # returns a dictionary for the move action
+        return {
+            "attack type": self.attackType,
+            "type": self.type,
+            "aniStatus": self.aniStatus,
+            "alternative": self.alternative,
+            "flipped": False,
+            "point": None
+        }
+
 def isfloat(stringVal):
     # checks and sees if a string is an eligible float
     try:

--- a/JSON/Items/Item_Effects.json
+++ b/JSON/Items/Item_Effects.json
@@ -1,65 +1,78 @@
 {
    "Old Bread": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+20 Hp"
    },
    "Potion": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+100 Hp"
    },
    "Ether": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+50 Mp"
    },
    "Hi-Ether": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+100 Mp"
    },
    "Hi-Potion": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+200 Hp"
    },
    "Dragon Tear": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+50% Hp"
    },
    "Medicinal Herbs": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "Cure Poison"
    },
    "Bandages": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "Cure Bleed"
    },
    "Elixir": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "+100% Hp | +100% Mp | Cure All"
    },
    "Ointment": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "Cure Burn"
    },
    "Paralyze Tonic": {
+      "Type": "Heal",
       "Target": "S",
       "AOE": false,
       "Effect": "Cure Paralyze"
    },
    "Bomb": {
+      "Type": "Attack",
       "Target": "T",
       "AOE": true,
       "Effect": "-100 Hp, T"
    },
    "Super Bomb": {
+      "Type": "Attack",
       "Target": "T",
       "AOE": true,
       "Effect": "-100% Hp, T"

--- a/Rpg2.py
+++ b/Rpg2.py
@@ -214,6 +214,8 @@ while True:
                     # when we're done reading through the dialogue, check battle state
                     if len(dialogueManager.dialogue) == 0:
                         battleManager.determine_battle_state()  # checks to see if the battle state has changed
+                if not animationManager.active:  # check to see if the animation manager was just de-activated
+                    battleManager.determine_battle_state()  # checks to see if the battle state has changed
             else:
                 entityGroup.update()  # update the entities
                 entityGroup.draw(screen)  # draw the entities

--- a/Scripts.py
+++ b/Scripts.py
@@ -116,7 +116,9 @@ if __name__ == "__main__":
             if itemInfo["Effect"] and itemEffectDict.get(item) is None:
                 itemEffectDict.update({
                     item: {
+                        "Type": "Heal",
                         "Target": "",
+                        "AOE": False,
                         "Effect": ""
                     }
                 })

--- a/managers/Item_Manager.py
+++ b/managers/Item_Manager.py
@@ -57,6 +57,7 @@ class ItemManager:
             return self.itemEffectJson[item]
         else:
             return {
+                "Type": "",
                 "Target": "",
                 "AOE": "",
                 "Effect": ""
@@ -65,6 +66,19 @@ class ItemManager:
     def get_effect(self, item):
         # returns the effect string if the item has an effect or returns empty string
         return self.get_effect_details(item)["Effect"]
+
+    # formats a dictionary to return for action manager
+    def get_action_details(self, item):
+        itemEffect = self.get_effect_details(item)
+        return {
+            "attack type": "",
+            "type": itemEffect["Type"],
+            "aniStatus": "Attack1",
+            "alternative": "Attack1",
+            "flipped": False,
+            "point": None
+        }
+
 
     def get_parsable_item_info(self, item):
         # return a dictionary that's easier to parse


### PR DESCRIPTION
### Pygame-RPG 25.1 Housekeeping and bugfixing

This change is about fixing the animations when an item is used and addressing a bug with when the item kills all enemies after the integration.

Firstly, the animations for when an item is used cannot just be a static animation. The reason for this is simple, some items should have differing effects on what animations are played. For example, using a damaging item should make the target go into a "Hurt" animation while using a healing item shouldn't. Currently however, our `AnimationManager` cannot handle this because the `load_action_queue` function get's the animation information from a `Move` object.

To address this, the `load_action_queue()` no longer takes in a `Move` object but a structured dictionary containing all of the key-pairs that are needed to set up an animation.

Because of this, the `Move` class received a new function, `get_action_details()`, which returns a structured dictionary based off of the given `Move` object.

For items, however, the `Item_Effects.json` file needed to have a new key called "Type" which is an indicator used in `AnimationManager`. Also, `ItemManager` has a new function, `get_action_details()`. Unlike the same function in the `Move` class, this function takes in a string name and then returns the structured dictionary.

Secondly, the afformentioned bug was solved by simply adding a condition for when the animation manager was inactive to check the battle's state using the `determine_battle_state()` function from `BattleManager`.

Other Changes:
- Updated .idea files since I'm on a new computer
- Updated the way the targets were handled for animation manager in Rpg2.py
- Updated tests
- Updated scripts

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 