### PR TITLE
Pygame-RPG 26 Fixing Animation Height

### DIFF
--- a/Entity/Entities_test.py
+++ b/Entity/Entities_test.py
@@ -38,7 +38,7 @@ def test_update():
     knight.y = 999  # set a new position
     knight.update()  # update the knight
     # confirm that the rectangle shifted to the knight's coordinates
-    flag5 = knight.rect.center != oldRectPos and knight.rect.center == (knight.x, knight.y)
+    flag5 = knight.rect.center != oldRectPos and knight.rect.midbottom == (knight.x, knight.y)
     assert flag and flag2 and flag3 and flag4 and flag5
 
 

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -54,11 +54,11 @@ class Entity(game.sprite.Sprite):
             self.image = game.transform.flip(self.image, True, False)  # flip across y axis
         self.image = game.transform.scale(self.image, self.Scale)  # scale the image
         self.rect = self.image.get_rect()  # get the new rectangle
-        self.rect.center = (self.x, self.y)  # center the rectangle to the players coordinates
+        self.rect.midbottom = (self.x, self.y)  # center the rectangle to the players coordinates
 
     def update(self, force=False):
-        if self.rect.center != (self.x, self.y):  # check if the entity moved
-            self.rect.center = (self.x, self.y)  # center the rectangle
+        if self.rect.midbottom != (self.x, self.y):  # check if the entity moved
+            self.rect.midbottom = (self.x, self.y)  # center the rectangle
         # this behavior is for overworld behavior
         if self.aniTracker != -1:  # -1 means that the animation is stuck for it
             self.aniTracker += 1  # increment the tracker

--- a/Entity/Knight.py
+++ b/Entity/Knight.py
@@ -23,7 +23,7 @@ class Knight(Entity):
             "Accessory": None
         }
         self.default_x = 0  # default x value
-        self.default_y = 590  # default y value 350 works for battles
+        self.default_y = 740  # default y value 350 works for battles
         self.x = self.default_x  # set the x value
         self.y = self.default_y  # set the y value
         self.reset_max_animation_val()  # set the limit

--- a/save/save_data1.json
+++ b/save/save_data1.json
@@ -4,7 +4,7 @@
       "aniStatus": "Idle",
       "aniTracker": 0,
       "x": 0,
-      "y": 590,
+      "y": 740,
       "flipped": false,
       "Name": "Knight",
       "Sprite": "Entity_Sprites/Knight/",
@@ -13,17 +13,17 @@
          -1
       ],
       "Lvl": 1,
-      "Hpcap": 52174,
-      "Hp": 52174,
-      "Mpcap": 52174,
-      "Mp": 52174,
+      "Hpcap": 766,
+      "Hp": 766,
+      "Mpcap": 766,
+      "Mp": 766,
       "Exp": 0,
       "Bal": 0,
-      "Str": 52174,
+      "Str": 766,
       "Mag": 1,
-      "Vit": 52174,
-      "Agl": 52174,
-      "Def": 52174,
+      "Vit": 766,
+      "Agl": 766,
+      "Def": 766,
       "moveList": [
          "Attack"
       ],
@@ -63,10 +63,10 @@
       }
    },
    "rawVariables": {
-      "animationTracker": 87,
-      "animationTracker2": 17,
-      "animationTracker3": 14,
-      "gameState": 2
+      "animationTracker": 29,
+      "animationTracker2": 11,
+      "animationTracker3": 27,
+      "gameState": 5
    },
    "screenManager": {
       "context": "Background1",
@@ -237,6 +237,24 @@
             500,
             650
          ]
+      },
+      "Werewolf": {
+         "Name": "Werewolf",
+         "Sprite": "Object_Sprites/Werewolf/",
+         "Scale": [],
+         "Flipped": false,
+         "Events": [],
+         "Context": "",
+         "Pos": []
+      },
+      "Witch": {
+         "Name": "Witch",
+         "Sprite": "Object_Sprites/Witch/",
+         "Scale": [],
+         "Flipped": false,
+         "Events": [],
+         "Context": "",
+         "Pos": []
       }
    },
    "objectDict": {

--- a/save/save_data4.json
+++ b/save/save_data4.json
@@ -4,7 +4,7 @@
       "aniStatus": "Idle",
       "aniTracker": 0,
       "x": 0,
-      "y": 590,
+      "y": 740,
       "flipped": false,
       "Name": "Knight",
       "Sprite": "Entity_Sprites/Knight/",
@@ -13,17 +13,17 @@
          -1
       ],
       "Lvl": 1,
-      "Hpcap": 52174,
-      "Hp": 52174,
-      "Mpcap": 52174,
-      "Mp": 52174,
+      "Hpcap": 766,
+      "Hp": 766,
+      "Mpcap": 766,
+      "Mp": 766,
       "Exp": 0,
       "Bal": 0,
-      "Str": 52174,
+      "Str": 766,
       "Mag": 1,
-      "Vit": 52174,
-      "Agl": 52174,
-      "Def": 52174,
+      "Vit": 766,
+      "Agl": 766,
+      "Def": 766,
       "moveList": [
          "Attack"
       ],
@@ -63,10 +63,10 @@
       }
    },
    "rawVariables": {
-      "animationTracker": 87,
-      "animationTracker2": 17,
-      "animationTracker3": 14,
-      "gameState": 2
+      "animationTracker": 29,
+      "animationTracker2": 11,
+      "animationTracker3": 27,
+      "gameState": 5
    },
    "screenManager": {
       "context": "Background1",
@@ -237,6 +237,24 @@
             500,
             650
          ]
+      },
+      "Werewolf": {
+         "Name": "Werewolf",
+         "Sprite": "Object_Sprites/Werewolf/",
+         "Scale": [],
+         "Flipped": false,
+         "Events": [],
+         "Context": "",
+         "Pos": []
+      },
+      "Witch": {
+         "Name": "Witch",
+         "Sprite": "Object_Sprites/Witch/",
+         "Scale": [],
+         "Flipped": false,
+         "Events": [],
+         "Context": "",
+         "Pos": []
       }
    },
    "objectDict": {


### PR DESCRIPTION
### Pygame-RPG 26 Fixing Animation Height
This PR is meant to address an oversight in the code. Previously, the line followed by the actor to their target, another sprite object, was drawn using the center of the actor's rectangle as a starting point and the target's center as the end point.

The problem with this is that the sprites all have unique shapes and sizes which causes the center of their rectangles to have unique quirks as well. As a result, the animations did not come out as intended as the sprites were not in line with each other when delivering their attacks.

To solve this, instead of basing the movement of the entities off of the center of the rectangles, instead, we base it off the middle bottom of their rectangles. By doing this, they are more in line with the original vision. As a result of doing this, the default y value for the `Knight` object was changed from 590, to 740.

As of the moment, I have no plans on implementing the same change to the other `Sprite` (`Object` and `NPC`) mostly because I don't need too. In the future, to streamline things I might. Also, due to this change, `BattleManager` will need some changes. While the animations play out fine, the cursor location as well as the location of the Entities are off.

Other Changes:
- Updated save files
- Updated test files

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 