### PR TITLE
Pygame-RPG 27.2 Housekeeping and bugfixing

### DIFF
--- a/Entity/Animation_Manager_test.py
+++ b/Entity/Animation_Manager_test.py
@@ -85,7 +85,7 @@ def test_change_animation_target():
     # confirm that the knight object is still dead (confirm that flipped stays the same)
     flag3 = knight.aniStatus == "Death" and knight.maxAniVal == 10 and knight.flipped and knight.aniTracker == 50
     # confirm that the goblin's animation changed and the animation tracker was reset
-    flag4 = goblin.aniStatus == "Idle" and goblin.maxAniVal == 6 and not goblin.flipped and goblin.aniTracker == 1
+    flag4 = goblin.aniStatus == "Idle" and goblin.maxAniVal == 6 and not goblin.flipped and goblin.aniTracker == 0
     knight.aniStatus = "Idle"  # set the animation manually
     knight.reset_max_animation_val()  # reset the maximum
     assert flag and flag2 and flag3 and flag4

--- a/Entity/Entities_test.py
+++ b/Entity/Entities_test.py
@@ -29,17 +29,19 @@ def test_update():
     flag2 = knight.aniTracker == knight.maxAniVal * 10 + 6  # confirm that the tracker didn't get reset
     knight.update(True)  # force update
     flag3 = knight.aniTracker == 0  # confirm it reset
+    knight.update(True)  # force update again
+    flag4 = knight.aniTracker == 0  # confirm forced upadtes don't increment aniTracker
     knight.aniTracker = knight.maxAniVal * 10 + 9  # set it right up until the last interval
     knight.update()  # update normally
-    flag4 = knight.aniTracker == 0  # confirm it reset on the interval
+    flag5 = knight.aniTracker == 0  # confirm it reset on the interval
     # check to see if the image and rectangle were updated and the animation tracker was reset
     oldRectPos = knight.rect.center  # set the old rectangle position
     knight.x = 999  # set a new position
     knight.y = 999  # set a new position
     knight.update()  # update the knight
     # confirm that the rectangle shifted to the knight's coordinates
-    flag5 = knight.rect.center != oldRectPos and knight.rect.midbottom == (knight.x, knight.y)
-    assert flag and flag2 and flag3 and flag4 and flag5
+    flag6 = knight.rect.center != oldRectPos and knight.rect.midbottom == (knight.x, knight.y)
+    assert flag and flag2 and flag3 and flag4 and flag5 and flag6
 
 
 def test_take_damage():

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -59,8 +59,8 @@ class Entity(game.sprite.Sprite):
     def update(self, force=False):
         if self.rect.midbottom != (self.x, self.y):  # check if the entity moved
             self.rect.midbottom = (self.x, self.y)  # center the rectangle
-        # this behavior is for overworld behavior
-        if self.aniTracker != -1:  # -1 means that the animation is stuck for it
+        # -1 means that the animation is stuck for it and forced updates shouldn't add to the animation tracker
+        if self.aniTracker != -1 and not force:
             self.aniTracker += 1  # increment the tracker
         if self.aniTracker % 10 == 0 or force:  # every 10 frames we shift the animation or if we force it
             update = False  # indicator for if an update is needed

--- a/Entity/Interactable.py
+++ b/Entity/Interactable.py
@@ -57,7 +57,8 @@ class Interactable(game.sprite.Sprite):
 
     # what the update function of the child class is actually going to do
     def super_update(self, name, force):
-        if self.aniTracker != -1:  # -1 indicates that it can't change
+        # -1 indicates that it can't change and the animation tracker shouldn't update when forced
+        if self.aniTracker != -1 and not force:
             self.aniTracker += 1  # increment the tracker
         if self.aniTracker % 10 == 0 or force:  # every 10 frames we shift the animation or when we force it
             update = False  # flag for when we should update the image and rect

--- a/Entity/NPC_test.py
+++ b/Entity/NPC_test.py
@@ -20,5 +20,7 @@ def test_update():
     flag3 = npc.aniTracker == (npc.maxAniVal * 10) + 6  # check to see if aniTracker was upped
     npc.update(True)  # force the update
     flag4 = npc.aniTracker == 0  # check to see if the tracker was reset
-    assert flag and flag2 and flag3 and flag4
+    npc.update(True)  # force another update
+    flag5 = npc.aniTracker == 0  # check to see if a forced update incremented aniTracker
+    assert flag and flag2 and flag3 and flag4 and flag5
 


### PR DESCRIPTION
### Pygame-RPG 27.2 Housekeeping and bugfixing
This PR is meant to address a simple oversight. Forced updates (calling `update()` and giving it the True flag) is meant to correct the animation of the `Sprite` object, nothing else. However, forced updates also update the `aniTracker` attribute of the `Sprite` object which was unintended. To fix this, I simply added a new condition for the `aniTracker` to be incremented.

Other Changes:
- Updated tests

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 