### PR TITLE
Pygame-RPG 28 Overhauling Animation Manager

### DIFF
--- a/Entity/Battle_Manager.py
+++ b/Entity/Battle_Manager.py
@@ -338,8 +338,10 @@ class BattleManager:
     def determine_battle_state(self):
         if len(self.enemies) == 0 and self.knight.Status[0] != "Dead":
             self.battleState = (False, "Hero Wins")  # Battle ended, hero wins
+            self.animationManager.deadGroup.empty()
         elif self.knight.Status[0] == "Dead":
             self.battleState = (False, "Hero Loses")  # Battle ended, hero lost
+            self.animationManager.deadGroup.empty()
         elif len(self.enemies) != 0 and self.knight.Status[0] != "Dead":  # Battle is on going
             self.battleState = (True, "")
 

--- a/Entity/Battle_Manager_test.py
+++ b/Entity/Battle_Manager_test.py
@@ -1,3 +1,4 @@
+from Entity.Animation_Manager_test import goblin
 from Entity.Knight import Knight
 from Entity.Entity_Factory import EntityFactory
 from Entity.Animation_Manager import AnimationManager
@@ -166,19 +167,22 @@ def test_get_entity_from_pos():
     assert entity == knight and entity2 == dummy
 
 def test_determine_battle_state():
-    # kill hero and see if the state is changed appropriately
+    animationManager.deadGroup.add(goblin)  # add goblin to the group
+    # kill hero and see if the state is changed appropriately also check if the dead group is emptied
     knight.Status = ("Dead", -1)
     battleManager.determine_battle_state()
-    flag = battleManager.battleState == (False, "Hero Loses")
+    flag = battleManager.battleState == (False, "Hero Loses") and len(animationManager.deadGroup.sprites()) == 0
     # revive hero and determine if the state is changed appropriately
     knight.Status = ("Normal", -1)
     battleManager.determine_battle_state()
+    animationManager.deadGroup.add(goblin)  # add goblin to the group
     # change the battle state and confirm that the boolean for animationManager has not changed
-    flag2 = battleManager.battleState == (True, "")
+    flag2 = battleManager.battleState == (True, "") and len(animationManager.deadGroup.sprites()) == 1
     # get rid of all enemies and determine if the state is changed appropriately
     battleManager.enemies.clear()
+    animationManager.deadGroup.add(goblin)  # add goblin to the group
     battleManager.determine_battle_state()
-    flag3 = battleManager.battleState == (False, "Hero Wins")
+    flag3 = battleManager.battleState == (False, "Hero Wins") and len(animationManager.deadGroup.sprites()) == 0
     # check all flags
     assert flag and flag2 and flag3
 

--- a/Rpg2.py
+++ b/Rpg2.py
@@ -219,6 +219,8 @@ while True:
             else:
                 entityGroup.update()  # update the entities
                 entityGroup.draw(screen)  # draw the entities
+                animationManager.deadGroup.update()  # update the dead group
+                animationManager.deadGroup.draw(screen)  # draw the dead entities
                 if buffered_move != "" and len(targets) == battleManager.targetNum:
                     buffered_move = ""  # reset the move string
                     targets.clear()  # remove the targets from the list


### PR DESCRIPTION

### Pygame-RPG 28 Overhauling Animation Manager
While Animation Manager is currently functional it does have it's flaws. The main flaw being that it's animations are based off of the length of the actor's animation. This works really well if the actor's animations are the longest but that is not always the case.

These changes are meant to remedy that problem.

The first main change is splitting the responsibilities of the `spriteGroup` attribute into 3 other groups. These groups are the following:

`primaryGroup`: This is a sprite group who's animations matter, meaning that they are actively involved in the action being performed (i.e they're attacking or being attacked)

`secondaryGroup`: These are the sprites that are bystanders (normally just playing their idle animation)

`deadGroup`: These are the Entities that have already died but since the battle isn't over, their bodies from their death animation need to remain on the battlefield.

`reset()` now empties `primaryGroup` and `secondaryGroup` but does NOT empty `deadGroup`. This is so that the dead Entities are still animated.

Because of these changes, `fill_sprite_group()` now takes in 2 parameters, a sprite group and a list of entities. It now adds the entities to the sprite group given in the function.

Furthermore, alongside these changes, the `AnimationManager` now needs to consider two different types of actions. Actions that are based off of the frame count or actions based off of the animations in primary group.

In the first scenario, the `ActionManager` works as normal, counting up to a specified cap before resetting. The second scenario however, requires all of the Sprites in the `primaryGroup` sprite group to have finished their animations.

The indicator for which scenario occurs is in the `action` dictionary under the `Frame Count`. If the mapped value is True, the first scenario occurs, otherwise the second scenario occurs.

An example of an action that causes the first scenario would be actions that have a specified end point (i.e. actor is moving from point A to B). An example of the second scenario would be an attacking action (i.e. actor attacks targets)

The indicator is added to the action dictionary in the `load_action_queue()` function.

To support the second scenario (Action can't end until all animations in the primary group have finished playing), two functions have been added, `pseudo_update()` and `is_over()`.

`pseudo_update()`: This function iterates through the `primaryGroup` attribute and only updates the sprites that haven't reached the end of their animation (i.e. `aniTracker != maxAniVal * 10 - 1).

`is_over()`: This function iterates through the `primaryGroup` attribute and checks if all the sprite animations have reached their end points (`aniTracker == maxAniVal * 10 - 1`). If all sprite animations meet this condition, the function returns True, otherwise it returns False.

Finally, to ensure that the dead Entities are still animated, the `fill_dead_group()` function was created.

`fill_dead_group()`: This function iterates through the primary group (since that's the only group that could contain a dead entity for now). If the entity's status is dead, it removes the entity from `primaryGroup` and adds it to a list. It then changes the animation for all of the entities in the list to "Death" (the death animation) and adds the entities in the list to `deadGroup`.

This way, even when the Entity objects are removed from `BattleManager`, their death animations are still drawn.

Because of the above changes, `process_action()` has changed  how it works. Now, `frameCount` is only incremented when the action dictionary's "Frame Count" key is mapped to True, if this is the case then `primaryGroup` is updated normally. Otherwise, `primaryGroup` is updated using the `pseudo_update()` function and `frameCount` is not incremented. Afterwards, `primaryGroup` is drawn. `secondaryGroup` and `deadGroup` are then updated using the `update()` function and drawn. Next, the reset condition has changed to address the two possible scenarios. These flags are "frameCount" and "isOver". If either are true (only one of them can be true at a time). it the condition will trigger. If the action is an attack, the `fill_dead_group()` function is called. Then, it performs the reset like before.

`BattleManager` also received some changes. The main change is that `deteremine_battle_state()` now has the responsibility of clearing `deadGroup` in the `AnimationManager`. This is because `deadGroup` should only be emptied when the battle is completely over and only `BattleManager` knows when that is.

Some changes were also made to the `Rpg2.py` file to accommodate the new changes made.

Other Changes:
- Tests Updated
- Added "Frame Count" key to action dictionary


## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 