### PR TITLE
Pygame-RPG 28.1 Housekeeping and bugfixing

### DIFF
--- a/Entity/Battle_Manager.py
+++ b/Entity/Battle_Manager.py
@@ -115,7 +115,6 @@ class BattleManager:
                 # self.print_all_statuses()  ######## DEBUG
         # clear dead enemies should return a string of people who died to returnable strings
         returnable_strings += self.clear_dead_enemies()  # removes dead entities and add event strings
-        self.fix_entity_stats()  # correct the stats of all entities that are still alive
         return returnable_strings, refresh
 
     def use_move(self, turnObject, move,  targets):
@@ -257,7 +256,9 @@ class BattleManager:
                 self.apply_effect_buff(effectTarget, effect)
             #print(effectString)
             returnableStrings.append(effectString)
+        self.fix_entity_stats()  # correct the stats of all entities that are still alive
         return returnableStrings
+
     def apply_effect_buff(self, target, buff):
         target.remove_bonuses(False)  # strip off bonuses but don't remove buffs
         target.Bonuses.update(buff)  # Overwrite the buffs

--- a/Rpg2.py
+++ b/Rpg2.py
@@ -216,6 +216,7 @@ while True:
                         battleManager.determine_battle_state()  # checks to see if the battle state has changed
                 if not animationManager.active:  # check to see if the animation manager was just de-activated
                     battleManager.determine_battle_state()  # checks to see if the battle state has changed
+
             else:
                 entityGroup.update()  # update the entities
                 entityGroup.draw(screen)  # draw the entities
@@ -254,8 +255,8 @@ while True:
                     if uiManager.subMenuSlider >= len(uiManager.subMenuItems) and len(uiManager.subMenuItems) != 0:
                         uiManager.subMenuSlider -= 1  # move slider back by 1
                 if len(returnable_strings) != 0:
-                    # load the event strings into the dialogue list
-                    dialogueManager.load_dialogue_list(returnable_strings)
+                    # load the event strings into the backlog
+                    dialogueManager.backlog += returnable_strings
         elif not battleManager.battleState[0] and battleManager.battleState[1] != "":
             entityFactory.clear_created_count()  # clear the dictionary
             # this means the battle ended and its result needs to be processed

--- a/managers/Dialogue_Manager.py
+++ b/managers/Dialogue_Manager.py
@@ -159,5 +159,3 @@ class DialogueManager:
                     self.dialogue.insert(1, " ".join(textList[i: len(textList)]))
                     break
             count += 3  # adjust for the 3 spaces we add later
-        # print("First line: " + str(self.firstLine))
-        # print("Second line: " + str(self.secondLine))


### PR DESCRIPTION

### Pygame-RPG 28.1 Housekeeping and bugfixing
The following changes are:

`fix_entity_stats()` is called in `apply_effects()` instead of at the end of `do_one_turn()` in `BattleManager`. The reason for this is because the latter leads to a visible glitch where an Entity can "Over Heal" (have more health than they should be allowed) before it get's fixed.

In `Rpg2.py`, `DialogueManager` now adds the list of strings from `BattleManager` to the `backlog` list instead of the `dialogue` list. This is because I believe that it would be better to communicate this information visually rather than through text. However, a battle log is going to be implemented eventually so this functionality isn't useless, it's just put aside for now.

I also removed some comments from `DialogueManager`.

## PR checklist
 - [x] All Pytests pass
 - [x] All changes are documented somewhere in the commit
 - [x] Rpg2.py is tested and works even with the changes
 